### PR TITLE
Be careful when archiving runs in detach mode

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click
 requests
+psutil
 pyyaml

--- a/taca/cli.py
+++ b/taca/cli.py
@@ -22,10 +22,10 @@ def cli(ctx, config_file):
 	""" Tool for the Automation of Storage and Analyses """
 
 	ctx.obj = {}
-	ctx.obj['config'] = config.load_yaml_config(config_file)
-	log_file = ctx.obj['config'].get('log', {}).get('log_file', None)
+	config = config.load_yaml_config(config_file)
+	log_file = config.get('log', {}).get('log_file', None)
 	if log_file:
-		level = ctx.obj['config'].get('log').get('log_level', 'INFO')
+		level = config.get('log').get('log_level', 'INFO')
 		taca.log.init_logger_file(log_file, level)
 
 

--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -23,7 +23,7 @@ def archive(ctx, backend):
 	"""
 	params = ctx.parent.params
 	if backend == 'swestore':
-		st.archive_to_swestore(ctx.obj['config'], days=params.get('days'), run=params.get('run'))
+		st.archive_to_swestore(days=params.get('days'), run=params.get('run'))
 
 
 @storage.command()
@@ -31,4 +31,4 @@ def archive(ctx, backend):
 def cleanup(ctx):
 	""" Move old runs to nosync directory so they're not synced to the processing server """
 	params = ctx.parent.params
-	st.cleanup(ctx.obj['config'], days=params.get('days'))
+	st.cleanup(days=params.get('days'))

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -77,7 +77,7 @@ def _archive_run(config, run):
             LOG.info('Run {} sent correctly and checksum was okay.'.format(f))
         else:
             LOG.warn('Run {} is already in Swestore or currently being archived, not sending it again'.format(f))
-        if remove and not misc.exists_process_with_text(run):
+        if remove and filesystem.is_in_swestore(run) and not misc.exists_process_with_text(run):
             LOG.info('Removing run'.format(f))
             os.remove(f)
 

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -71,7 +71,7 @@ def _archive_run(config, run):
         """
         if not filesystem.is_in_swestore(f):
             LOG.info("Sending {} to swestore".format(f))
-            misc.call_external_command_detached('iput -K -P {file} {dest}'.format(file=f, dest=dest),
+            misc.call_external_command('iput -K -P {file} {dest}'.format(file=f, dest=dest),
                     with_log_files=True)
             LOG.info('Run {} sent correctly and checksum was okay.'.format(f))
         else:

--- a/taca/utils/config.py
+++ b/taca/utils/config.py
@@ -4,6 +4,8 @@ import ConfigParser
 import os
 import yaml
 
+CONFIG = {}
+
 def load_config(config_file=None):
     """Loads a configuration file.
 
@@ -32,7 +34,8 @@ def load_yaml_config(config_file):
     :raises IOError: If the config file cannot be opened.
     """
     if type(config_file) is file:
-        return yaml.load(config_file)
+        CONFIG = yaml.load(config_file)
+        return CONFIG
     else:
         try:
             with open(config_file, 'r') as f:

--- a/taca/utils/misc.py
+++ b/taca/utils/misc.py
@@ -1,6 +1,7 @@
 """ Miscellaneous or general-use methods
 """
 import os
+import psutil
 import subprocess
 import sys
 
@@ -19,9 +20,8 @@ def call_external_command(cl, with_log_files=False):
     stderr = sys.stderr
 
     if with_log_files:
-        time = datetime.now()
-        stdout = open(command + '_{}{}{}.out'.format(time.hour, time.minute, time.second), 'wa')
-        stderr = open(command + '_{}{}{}.err'.format(time.hour, time.minute, time.second), 'wa')
+        stdout = open(command + '.out', 'wa')
+        stderr = open(command + '.err', 'wa')
         started = "Started command {} on {}".format(' '.join(cl), datetime.now())
         stdout.write(started + '\n')
         stdout.write(''.join(['=']*len(cl)) + '\n')
@@ -51,9 +51,8 @@ def call_external_command_detached(cl, with_log_files=False):
     stderr = sys.stderr
 
     if with_log_files:
-        time = datetime.now()
-        stdout = open(command + '_{}{}{}.out'.format(time.hour, time.minute, time.second), 'wa')
-        stderr = open(command + '_{}{}{}.err'.format(time.hour, time.minute, time.second), 'wa')
+        stdout = open(command + '.out', 'wa')
+        stderr = open(command + '.err', 'wa')
         started = "Started command {} on {}".format(' '.join(cl), datetime.now())
         stdout.write(started + '\n')
         stdout.write(''.join(['=']*len(cl)) + '\n')
@@ -68,3 +67,14 @@ def call_external_command_detached(cl, with_log_files=False):
             stdout.close()
             stderr.close()
     return p_handle
+
+
+def exists_process_with_text(text):
+    """Checks wether it exists a process which command line contains <text>
+
+    :param str text: Text to be found in the command line string of the processes
+    """
+    for process in psutil.get_process_list():
+        if text in process.cmdline:
+            return True
+    return False


### PR DESCRIPTION
So I found a problem: If I detach the iput command, it will immediately remove the run, but it will 100% sure still be archiving so... problem! Also, I thought that `ils` would return the run only when it was totally archived but it doesn't, it shows the run (with size 0) as soon as I starts archiving. So I solved this issue getting the list of PIDs and checking if the command contains the run name. If that's the case that means that the run is being archived and therefore I don't remove it. I only remove the run **iff** it is in swestore **and** there is no process containing the run id...

what do you think @vezzi ?

**EDIT:**

- [x] What if the command fails? Will the data transferred till that moment be in swestore? Check that