### PR TITLE
Pooled archiving to swestore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click
 requests
+psutil
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 click
 requests
-psutil
 pyyaml

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'

--- a/taca/cli.py
+++ b/taca/cli.py
@@ -6,7 +6,7 @@ import taca.log
 from pkg_resources import iter_entry_points
 
 from taca import __version__
-from taca.utils import config
+from taca.utils import config as conf
 
 
 @click.group()
@@ -22,7 +22,7 @@ def cli(ctx, config_file):
 	""" Tool for the Automation of Storage and Analyses """
 
 	ctx.obj = {}
-	config = config.load_yaml_config(config_file)
+	config = conf.load_yaml_config(config_file)
 	log_file = config.get('log', {}).get('log_file', None)
 	if log_file:
 		level = config.get('log').get('log_level', 'INFO')

--- a/taca/cli.py
+++ b/taca/cli.py
@@ -22,10 +22,10 @@ def cli(ctx, config_file):
 	""" Tool for the Automation of Storage and Analyses """
 
 	ctx.obj = {}
-	ctx.obj['config'] = config.load_yaml_config(config_file)
-	log_file = ctx.obj['config'].get('log', {}).get('log_file', None)
+	config = config.load_yaml_config(config_file)
+	log_file = config.get('log', {}).get('log_file', None)
 	if log_file:
-		level = ctx.obj['config'].get('log').get('log_level', 'INFO')
+		level = config.get('log').get('log_level', 'INFO')
 		taca.log.init_logger_file(log_file, level)
 
 

--- a/taca/log/__init__.py
+++ b/taca/log/__init__.py
@@ -32,3 +32,7 @@ def init_logger_file(log_file, log_level='INFO'):
     fh.setLevel(log_level)
     fh.setFormatter(formatter)
     LOG.addHandler(fh)
+
+def get_logger():
+    """ Returns global logger """
+    return LOG

--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -23,7 +23,7 @@ def archive(ctx, backend):
 	"""
 	params = ctx.parent.params
 	if backend == 'swestore':
-		st.archive_to_swestore(ctx.obj['config'], days=params.get('days'), run=params.get('run'))
+		st.archive_to_swestore(days=params.get('days'), run=params.get('run'))
 
 
 @storage.command()
@@ -31,4 +31,4 @@ def archive(ctx, backend):
 def cleanup(ctx):
 	""" Move old runs to nosync directory so they're not synced to the processing server """
 	params = ctx.parent.params
-	st.cleanup(ctx.obj['config'], days=params.get('days'))
+	st.cleanup(days=params.get('days'))

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -77,7 +77,7 @@ def _archive_run(config, run):
             LOG.info('Run {} sent correctly and checksum was okay.'.format(f))
         else:
             LOG.warn('Run {} is already in Swestore or currently being archived, not sending it again'.format(f))
-        if remove and not misc.exists_process_with_text(run):
+        if remove and filesystem.is_in_swestore(run) and not misc.exists_process_with_text(run):
             LOG.info('Removing run'.format(f))
             os.remove(f)
 

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -50,16 +50,15 @@ def archive_to_swestore(days, run=None):
             LOG.info('Checking {} directory'.format(to_send_dir))
             with filesystem.chdir(to_send_dir):
                 for run in [r for r in os.listdir(to_send_dir) if re.match(filesystem.RUN_RE, r)]:
-                    _archive_run(config, run)
+                    _archive_run(run)
 
 
 #############################################################
 # Class helper methods, not exposed as commands/subcommands #
 #############################################################
-def _archive_run(config, run):
+def _archive_run(run):
     """ Archive a specific run to swestore
 
-    :param dict config: Dictionary with configurations
     :param str run: Run directory
     """
     def _send_to_swestore(f, dest, remove=True):

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -73,6 +73,8 @@ def _archive_run((run,)):
     :param str run: Run directory
     """
     config = config.get_config()
+    LOG = get_logger()
+    
     def _send_to_swestore(f, dest, remove=True):
         """ Send file to swestore checking adler32 on destination and eventually
         removing the file from disk

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -71,7 +71,7 @@ def _archive_run(config, run):
         """
         if not filesystem.is_in_swestore(f):
             LOG.info("Sending {} to swestore".format(f))
-            misc.call_external_command_detached('iput -K -P {file} {dest}'.format(file=f, dest=dest),
+            misc.call_external_command('iput -K -P {file} {dest}'.format(file=f, dest=dest),
                     with_log_files=True)
             LOG.info('Run {} sent correctly and checksum was okay.'.format(f))
         else:

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -58,7 +58,7 @@ def archive_to_swestore(days, run=None):
                                             and not os.path.exists("{}.archiving".format(r.split('.')[0]))]
                 if to_be_archived:
                     pool = Pool(processes=len(to_be_archived))
-                    pool.map_async(_archive_run, ((run,) for i in to_be_archived))
+                    pool.map_async(_archive_run, ((run,) for run in to_be_archived))
                     pool.close()
                     pool.join()
                 else:
@@ -72,9 +72,9 @@ def _archive_run((run,)):
 
     :param str run: Run directory
     """
-    config = config.get_config()
+    config = get_config()
     LOG = get_logger()
-    
+
     def _send_to_swestore(f, dest, remove=True):
         """ Send file to swestore checking adler32 on destination and eventually
         removing the file from disk

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -75,7 +75,7 @@ def _archive_run((run,)):
         """
         if not filesystem.is_in_swestore(f):
             LOG.info("Sending {} to swestore".format(f))
-            misc.call_external_command_detached('iput -K -P {file} {dest}'.format(file=f, dest=dest),
+            misc.call_external_command('iput -K -P {file} {dest}'.format(file=f, dest=dest),
                     with_log_files=True)
             LOG.info('Run {} sent correctly and checksum was okay.'.format(f))
         else:

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -55,7 +55,7 @@ def archive_to_swestore(days, run=None):
             LOG.info('Checking {} directory'.format(to_send_dir))
             with filesystem.chdir(to_send_dir):
                 to_be_archived = [r for r in os.listdir(to_send_dir) if re.match(filesystem.RUN_RE, r)
-                                            and not os.path.exists("{}.archiving".format(run.split('.')[0]))]
+                                            and not os.path.exists("{}.archiving".format(r.split('.')[0]))]
                 if to_be_archived:
                     pool = Pool(processes=len(to_be_archived))
                     pool.map_async(_archive_run, ((run,) for i in to_be_archived))

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -53,7 +53,7 @@ def archive_to_swestore(days, run=None):
                 to_be_archived = [r for r in os.listdir(to_send_dir) if re.match(filesystem.RUN_RE, r)
                                             and not os.path.exists("{}.archiving".format(run))]
                 pool = Pool(processes=len(to_be_archived))
-                pool.map_async(_archive_run, ((run,) for i in to_be_archived)
+                pool.map_async(_archive_run, ((run,) for i in to_be_archived))
                 pool.close()
                 pool.join()
 

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -5,6 +5,8 @@ import re
 import shutil
 import time
 
+from multiprocessing import Pool
+
 from taca.log import LOG
 from taca.utils.config import CONFIG as config
 from taca.utils import filesystem, misc
@@ -45,18 +47,20 @@ def archive_to_swestore(days, run=None):
     # Otherwise find all runs in every data dir on the nosync partition
     else:
         LOG.info("Archiving old runs to SWESTORE")
-        for data_dir in config.get('storage').get('data_dirs'):
-            to_send_dir = os.path.join(data_dir, 'nosync')
+        for to_send_dir in config.get('storage').get('archive_dirs'):
             LOG.info('Checking {} directory'.format(to_send_dir))
             with filesystem.chdir(to_send_dir):
-                for run in [r for r in os.listdir(to_send_dir) if re.match(filesystem.RUN_RE, r)]:
-                    _archive_run(run)
-
+                to_be_archived = [r for r in os.listdir(to_send_dir) if re.match(filesystem.RUN_RE, r)
+                                            and not os.path.exists("{}.archiving".format(run))]
+                pool = Pool(processes=len(to_be_archived))
+                pool.map_async(_archive_run, ((run,) for i in to_be_archived)
+                pool.close()
+                pool.join()
 
 #############################################################
 # Class helper methods, not exposed as commands/subcommands #
 #############################################################
-def _archive_run(run):
+def _archive_run((run,)):
     """ Archive a specific run to swestore
 
     :param str run: Run directory
@@ -69,16 +73,18 @@ def _archive_run(run):
         :param str dest: Destination directory in Swestore
         :param bool remove: If True, remove original file from source
         """
-        if not filesystem.is_in_swestore(f) and not misc.exists_process_with_text(run):
+        if not filesystem.is_in_swestore(f):
+            open("{}.archiving".format(f), 'w').close()
             LOG.info("Sending {} to swestore".format(f))
             misc.call_external_command_detached('iput -K -P {file} {dest}'.format(file=f, dest=dest),
                     with_log_files=True)
             LOG.info('Run {} sent correctly and checksum was okay.'.format(f))
         else:
-            LOG.warn('Run {} is already in Swestore or currently being archived, not sending it again'.format(f))
-        if remove and filesystem.is_in_swestore(run) and not misc.exists_process_with_text(run):
+            LOG.warn('Run {} is already in Swestore, not sending it again'.format(f))
+        if remove and filesystem.is_in_swestore(run):
             LOG.info('Removing run'.format(f))
             os.remove(f)
+        os.remove("{}.archiving".format(f))
 
 
     if run.endswith('bz2'):

--- a/taca/utils/config.py
+++ b/taca/utils/config.py
@@ -4,6 +4,8 @@ import ConfigParser
 import os
 import yaml
 
+CONFIG = {}
+
 def load_config(config_file=None):
     """Loads a configuration file.
 
@@ -32,7 +34,8 @@ def load_yaml_config(config_file):
     :raises IOError: If the config file cannot be opened.
     """
     if type(config_file) is file:
-        return yaml.load(config_file)
+        CONFIG = yaml.load(config_file)
+        return CONFIG
     else:
         try:
             with open(config_file, 'r') as f:

--- a/taca/utils/config.py
+++ b/taca/utils/config.py
@@ -34,7 +34,7 @@ def load_yaml_config(config_file):
     :raises IOError: If the config file cannot be opened.
     """
     if type(config_file) is file:
-        CONFIG = yaml.load(config_file)
+        CONFIG.update(yaml.load(config_file))
         return CONFIG
     else:
         try:
@@ -43,3 +43,8 @@ def load_yaml_config(config_file):
         except IOError as e:
             e.message = "Could not open configuration file \"{}\".".format(config_file)
             raise e
+
+
+def get_config():
+    """ Returns global configuration """
+    return CONFIG

--- a/taca/utils/misc.py
+++ b/taca/utils/misc.py
@@ -1,6 +1,7 @@
 """ Miscellaneous or general-use methods
 """
 import os
+import psutil
 import subprocess
 import sys
 
@@ -19,9 +20,8 @@ def call_external_command(cl, with_log_files=False):
     stderr = sys.stderr
 
     if with_log_files:
-        time = datetime.now()
-        stdout = open(command + '_{}{}{}.out'.format(time.hour, time.minute, time.second), 'wa')
-        stderr = open(command + '_{}{}{}.err'.format(time.hour, time.minute, time.second), 'wa')
+        stdout = open(command + '.out', 'wa')
+        stderr = open(command + '.err', 'wa')
         started = "Started command {} on {}".format(' '.join(cl), datetime.now())
         stdout.write(started + '\n')
         stdout.write(''.join(['=']*len(cl)) + '\n')
@@ -51,9 +51,8 @@ def call_external_command_detached(cl, with_log_files=False):
     stderr = sys.stderr
 
     if with_log_files:
-        time = datetime.now()
-        stdout = open(command + '_{}{}{}.out'.format(time.hour, time.minute, time.second), 'wa')
-        stderr = open(command + '_{}{}{}.err'.format(time.hour, time.minute, time.second), 'wa')
+        stdout = open(command + '.out', 'wa')
+        stderr = open(command + '.err', 'wa')
         started = "Started command {} on {}".format(' '.join(cl), datetime.now())
         stdout.write(started + '\n')
         stdout.write(''.join(['=']*len(cl)) + '\n')
@@ -68,3 +67,14 @@ def call_external_command_detached(cl, with_log_files=False):
             stdout.close()
             stderr.close()
     return p_handle
+
+
+def exists_process_with_text(text):
+    """Checks wether it exists a process which command line contains <text>
+
+    :param str text: Text to be found in the command line string of the processes
+    """
+    for process in psutil.get_process_list():
+        if text in process.cmdline:
+            return True
+    return False

--- a/taca/utils/misc.py
+++ b/taca/utils/misc.py
@@ -67,14 +67,3 @@ def call_external_command_detached(cl, with_log_files=False):
             stdout.close()
             stderr.close()
     return p_handle
-
-
-def exists_process_with_text(text):
-    """Checks wether it exists a process which command line contains <text>
-
-    :param str text: Text to be found in the command line string of the processes
-    """
-    for process in psutil.get_process_list():
-        if text in process.cmdline:
-            return True
-    return False

--- a/taca/utils/misc.py
+++ b/taca/utils/misc.py
@@ -1,7 +1,6 @@
 """ Miscellaneous or general-use methods
 """
 import os
-import psutil
 import subprocess
 import sys
 


### PR DESCRIPTION
This makes possible that several runs are sent to swestore simultaneously. It will pool an archiving process for each run to be archived and wait till all of them have finished. While archiving, it will create a state file so that other taca processes do not re-archive the runs.

Also, log and configs are now global. 