### PR TITLE
Cleanup for processing server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,4 @@
 
 This package contains several tools for projects and data management in the [National Genomics Infrastructure](https://portal.scilifelab.se/genomics/) in Stockholm, Sweden.
 
-For a more detailed documentation please go to [the documentation page](http://taca.readthedocs.org/en/latest/)
-
-### Contributors
-
-* [Guillermo Carrasco](https://github.com/guillermo-carrasco)
-* [Francesco Vezzi](https://github.com/vezzi)
+For a more detailed documentation please go to [the documentation page](http://taca.readthedocs.org/en/latest/).

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'

--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -5,7 +5,7 @@ from taca.storage import storage as st
 
 
 @click.group()
-@click.option('-d', '--days', default=10, help="Days to consider as thershold")
+@click.option('-d', '--days', type=click.INT, help="Days to consider as thershold")
 @click.option('-r', '--run', type=click.Path(exists=True))
 @click.pass_context
 def storage(ctx, days, run):

--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -16,13 +16,14 @@ def storage(ctx, days, run):
 @storage.command()
 @click.option('--backend', type=click.Choice(['swestore']), required=True,
               help='Long term storage backend')
+@click.option('-m','--max-runs', type=click.INT, help='Limit the number of runs to be archived simultaneously')
 @click.pass_context
-def archive(ctx, backend):
+def archive(ctx, backend, max_runs):
     """ Archive old runs to SWESTORE
 	"""
     params = ctx.parent.params
     if backend == 'swestore':
-        st.archive_to_swestore(days=params.get('days'), run=params.get('run'))
+        st.archive_to_swestore(days=params.get('days'), run=params.get('run'), max_runs)
 
 
 @storage.command()

--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -5,7 +5,7 @@ from taca.storage import storage as st
 
 
 @click.group()
-@click.option('-d', '--days', type=click.INT, help="Days to consider as thershold")
+@click.option('-d', '--days', default=10, help="Days to consider as thershold")
 @click.option('-r', '--run', type=click.Path(exists=True))
 @click.pass_context
 def storage(ctx, days, run):
@@ -16,14 +16,13 @@ def storage(ctx, days, run):
 @storage.command()
 @click.option('--backend', type=click.Choice(['swestore']), required=True,
               help='Long term storage backend')
-@click.option('-m','--max-runs', type=click.INT, help='Limit the number of runs to be archived simultaneously')
 @click.pass_context
-def archive(ctx, backend, max_runs):
+def archive(ctx, backend):
     """ Archive old runs to SWESTORE
 	"""
     params = ctx.parent.params
     if backend == 'swestore':
-        st.archive_to_swestore(days=params.get('days'), run=params.get('run'), max_runs)
+        st.archive_to_swestore(days=params.get('days'), run=params.get('run'))
 
 
 @storage.command()
@@ -38,7 +37,7 @@ def cleanup(ctx, site, dry_run):
     if site == 'nas':
         st.cleanup_nas(days)
     if site == 'processing-server':
-        raise NotImplementedError('Method for this site is not implemented yet')
+        st.cleanup_processing(days)
     if site == 'swestore':
         st.cleanup_swestore(days, dry_run)
     if site in ['illumina','analysis','archive']:

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -45,6 +45,8 @@ def cleanup_processing(days):
     config = get_config()
     LOG = get_logger()
     transfer_file = os.path.join(config.get('preprocessing', {}).get('status_dir'), 'transfer.tsv')
+    if not days:
+        days = config.get('cleanup', {}).get('processing-server', {}).get('days', 10)
     try:
         #Move finished runs to nosync
         for data_dir in config.get('storage').get('data_dirs'):

--- a/taca/utils/filesystem.py
+++ b/taca/utils/filesystem.py
@@ -54,3 +54,16 @@ def list_runs_in_swestore(path, pattern=RUN_RE, no_ext=False):
         return runs
     except CalledProcessError:
         return []
+
+
+def is_in_file(file_path, text):
+    """ Looks for text appearing in a file.
+
+    :param str file_path: Path to the source file
+    :param str text: Text to find in the file
+    :raises OSError: If the file does not exist
+    :returns bool: True is text is in file, False otherwise
+    """
+    with open(file_path, 'r') as f:
+        content = f.read()
+    return text in content

--- a/taca/utils/misc.py
+++ b/taca/utils/misc.py
@@ -1,10 +1,30 @@
 """ Miscellaneous or general-use methods
 """
 import os
+import smtplib
 import subprocess
 import sys
 
 from datetime import datetime
+from email.mime.text import MIMEText
+
+
+def send_mail(subject, content, receiver):
+    """ Sends an email
+
+    :param str subject: Subject for the email
+    :param str content: Content of the email
+    :param str receiver: Address to send the email
+    """
+    msg = MIMEText(content)
+    msg['Subject'] = "TACA - {}".format(subject)
+    msg['From'] = 'TACA'
+    msg['to'] = receiver
+
+    s = smtplib.SMTP('localhost')
+    s.sendmail('TACA', [receiver], msg.as_string())
+    s.quit()
+
 
 def call_external_command(cl, with_log_files=False, prefix=None):
     """ Executes an external command
@@ -36,7 +56,6 @@ def call_external_command(cl, with_log_files=False, prefix=None):
         if with_log_files:
             stdout.close()
             stderr.close()
-
 
 
 def call_external_command_detached(cl, with_log_files=False, prefix=None):
@@ -83,6 +102,7 @@ def days_old(date, date_format="%y%m%d"):
     except ValueError:
         return None
     return time_dif.days
+
 
 def query_yes_no(question, default="yes", force=False):
     """Ask a yes/no question via raw_input() and return their answer.


### PR DESCRIPTION
Implements `taca storage cleanup --site processing-server`. It will do two things:

1. Move finished **and transferred** runs to `nosync` directory. To know if they're transferred it will check the file `transfer.tsv`. If it does not find the file, it will send a mail to the contact specified in the configuration file, or to `user@localhost` if that contact is not found (not super useful, so specify that contact)
2. Remove old runs from `nosync`