### PR TITLE
Load global log andd conf implicitely

### DIFF
--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -10,9 +10,9 @@ import requests
 from datetime import datetime
 import re
 
-from taca.log import get_logger
+from taca.log import LOG
 from taca.utils.filesystem import chdir
-from taca.utils.config import get_config
+from taca.utils.config import CONFIG
 from taca.utils import parsers, misc
 
 def check_config_options(config):
@@ -92,7 +92,6 @@ def transfer_run(run, config, analysis=True):
     :param dict config: Parsed configuration
     :param bool analysis: Trigger analysis on remote server
     """
-    LOG = get_logger()
     with chdir(run):
         cl = ['rsync', '-av']
         # Add R/W permissions to the group
@@ -138,7 +137,6 @@ def trigger_analysis(run, config):
     :param str run: Run directory
     :param dict config: Parsed configuration
     """
-    LOG = get_logger()
     if not config.get('analysis'):
         LOG.warn(("No configuration found for remote analysis server. Not triggering"
                   "analysis of {}".format(os.path.basename(run))))
@@ -174,7 +172,6 @@ def prepare_sample_sheet(run, config):
         :param dict config: Parset configuration file
 
     """
-    LOG = get_logger()
     #start by checking if samplesheet is in the correct place
     run_name     = os.path.basename(run)
     current_year = '20' + run_name[0:2]
@@ -212,7 +209,6 @@ def samplesheet_massage(samplesheet_dict, samplesheet_name=''):
 
         :param dict FCID_samplesheet_origin_dict: the sample sheet stored in a hash table
     """
-    LOG = get_logger()
     #check that sample sheet is ok
     if not samplesheet_dict["Header"]:
         LOG.warn(("When trying to generate SampleSheet.csv for sample sheet {} I find out that "
@@ -254,7 +250,6 @@ def dict_to_samplesheet(samplesheet_dict, file_dest):
         :param str file_dest: destination file
 
     """
-    LOG = get_logger()
     try:
 
         with open(file_dest, 'wb') as csvfile:
@@ -290,7 +285,6 @@ def samplesheet_to_dict(samplesheet):
 
         :param str samplesheet: the sample sheet to be stored in the hash table
     """
-    LOG = get_logger()
     samplesheet_dict = {}
     try:
         section = ""
@@ -323,7 +317,6 @@ def run_bcl2fastq(run, config):
     :param str run: Run directory
     :param dict config: Parset configuration file
     """
-    LOG = get_logger()
     LOG.info('Building bcl2fastq command')
     with chdir(run):
         cl_options = config['bcl2fastq']
@@ -409,8 +402,7 @@ def run_bcl2fastq(run, config):
 
 def run_demultiplexing(run):
     """ Run demultiplexing in all data directories """
-    config = get_config()['preprocessing']
-    LOG = get_logger()
+    config = CONFIG['preprocessing']
 
     hiseq_runs = glob.glob(os.path.join(config['hiseq_data'], '1*XX')) if not run else [run]
     for run in hiseq_runs:

--- a/taca/log/__init__.py
+++ b/taca/log/__init__.py
@@ -32,7 +32,3 @@ def init_logger_file(log_file, log_level='INFO'):
     fh.setLevel(log_level)
     fh.setFormatter(formatter)
     LOG.addHandler(fh)
-
-def get_logger():
-    """ Returns global logger """
-    return LOG

--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -23,7 +23,7 @@ def archive(ctx, backend, max_runs):
 	"""
     params = ctx.parent.params
     if backend == 'swestore':
-        st.archive_to_swestore(days=params.get('days'), run=params.get('run'), max_runs)
+        st.archive_to_swestore(days=params.get('days'), run=params.get('run'), max_runs=max_runs)
 
 
 @storage.command()

--- a/taca/utils/config.py
+++ b/taca/utils/config.py
@@ -43,8 +43,3 @@ def load_yaml_config(config_file):
         except IOError as e:
             e.message = "Could not open configuration file \"{}\".".format(config_file)
             raise e
-
-
-def get_config():
-    """ Returns global configuration """
-    return CONFIG


### PR DESCRIPTION
Avoid this way having to declare this at the beginning of each method.

```python
LOG = get_logger()
config = get_config()
```

The reason that I didn't to this from the beginning is that I thought the the modules were loaded at the beginning, before populating the variables `LOG` and `CONFIG`, and thus they will be empty on use. But I have been testing and apparently that's not the case, so better. 