### PR TITLE
Vagrant provisioned by Ansible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ build
 _build
 *.log
 .DS*
-
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -12,4 +12,15 @@
 
 This package contains several tools for projects and data management in the [National Genomics Infrastructure](https://portal.scilifelab.se/genomics/) in Stockholm, Sweden.
 
+### Install for development
+You can setup a demo/development environment using [Vagrant][vagrant] provisioned by [Ansible][ansible].
+
+```bash
+$ ansible-galaxy install robinandeer.miniconda
+$ vagrant up && vagrant ssh
+
+# [inside virtual machince]
+$ bash /vagrant/provisioning/run-me.sh
+```
+
 For a more detailed documentation please go to [the documentation page](http://taca.readthedocs.org/en/latest/).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "phusion/ubuntu-14.04-amd64"
+
+  # Provision with Ansible
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "provisioning/playbook.yml"
+  end
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+end

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -1,0 +1,14 @@
+---
+- hosts: all
+  remote_user: vagrant
+  sudo: yes
+  roles:
+    - common
+    - robinandeer.miniconda
+
+  vars:
+    miniconda_modify_bashrc: yes
+    miniconda_environments:
+      - name: develop
+        python_version: 2.7
+        pkgs: 'pip ipython setuptools'

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: upgrade apt
+  sudo: yes
+  apt: upgrade=yes
+
+- name: install base packages
+  apt: name={{ item }} update_cache={{ update_apt_cache }} force=yes state=installed
+  with_items:
+    - build-essential
+    - git
+    - python-dev
+    - python-pip
+    - python-pycurl
+    - python-virtualenv
+    - supervisor
+    - wget
+    - vim
+    - tmux
+  tags: packages

--- a/provisioning/roles/common/vars/main.yml
+++ b/provisioning/roles/common/vars/main.yml
@@ -1,0 +1,2 @@
+---
+update_apt_cache: no

--- a/provisioning/run-me.sh
+++ b/provisioning/run-me.sh
@@ -1,9 +1,10 @@
 # activate environment
 source activate develop
 
-# install development dependencies
 cd /vagrant
-pip install -r ./requirements-dev.txt
 
 # install the package for development
 python setup.py develop
+
+# install development dependencies
+pip install -r ./requirements-dev.txt

--- a/provisioning/run-me.sh
+++ b/provisioning/run-me.sh
@@ -1,0 +1,9 @@
+# activate environment
+source activate develop
+
+# install development dependencies
+cd /vagrant
+pip install -r ./requirements-dev.txt
+
+# install the package for development
+python setup.py develop

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click
 requests
 pyyaml
+statusdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 click
 requests
 pyyaml
-statusdb


### PR DESCRIPTION
I don't know how people feel about this but I really like to setup Vagrant envs to test and develop more complicated projects like TACA.

This setup will create an Ubuntu box with conda installed ready for development :smile:

Perhaps useful? I added instructions on how to get started to the README

[EDIT: NO LONGER RELEVANT] I did remove the "statusdb" dependency from the requirements file since it doesn't appear to be present on PyPI but that was just me guessing :sweat_smile: