### PR TITLE
fix parent folder staging and corresponding tests

### DIFF
--- a/taca/deliver/deliver.py
+++ b/taca/deliver/deliver.py
@@ -128,21 +128,23 @@ class Deliverer(object):
                 (or None if source is a folder)
         """
         for sfile, dfile in getattr(self,'files_to_deliver',[]):
+            dest_path = self.expand_path(dfile)
             for f in glob.iglob(self.expand_path(sfile)):
                 if (os.path.isdir(f)):
+                    fparent = os.path.dirname(f)
                     # walk over all folders and files below
                     for pdir,_,files in os.walk(f):
                         for current in files:
                             fpath = os.path.join(pdir,current)
                             # use the relative path for the destination path
-                            fname = os.path.relpath(fpath,f)
+                            fname = os.path.relpath(fpath,fparent)
                             yield(fpath,
-                                os.path.join(self.expand_path(dfile),fname),
+                                os.path.join(dest_path,fname),
                                 hashfile(fpath,hasher=self.hash_algorithm) \
                                 if not self.no_checksum else None)
                 else:
                     yield (f, 
-                        os.path.join(self.expand_path(dfile),os.path.basename(f)), 
+                        os.path.join(dest_path,os.path.basename(f)), 
                         hashfile(f,hasher=self.hash_algorithm) \
                         if not self.no_checksum else None)
     

--- a/tests/data/taca_test_cfg.yaml
+++ b/tests/data/taca_test_cfg.yaml
@@ -39,7 +39,7 @@ deliver:
             - _ANALYSISPATH_/piper_ngi/03_genotype_concordance/concordance-check-result-file-should-go-here
             - _STAGINGPATH_/_SAMPLEID_/01-QC
         -
-            - _DATAPATH_/_SAMPLEID_/*/*
+            - _DATAPATH_/_SAMPLEID_/*
             - _STAGINGPATH_/_SAMPLEID_/02-FASTQ
         -
             - _ANALYSISPATH_/piper_ngi/05_processed_alignments/_SAMPLEID_.clean.dedup.recal.ba[im]


### PR DESCRIPTION
- This PR fixes an issue where in case a folder was specified in the "files_to_deliver" configuration option, the contained files and folders would be staged and transferred correctly but the folder itself would not be included as a parent folder in the delivery.
