### PR TITLE
BUGFIX: Call the method! not check if it exists

### DIFF
--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -294,7 +294,7 @@ def run_preprocessing(run):
         :param taca.illumina.Run run: Run to be processed and transferred
         """
         logger.info('Checking run {}'.format(run.id))
-        if run.is_finished:
+        if run.is_finished():
             if  run.status == 'TO_START':
                 logger.info(("Starting BCL to FASTQ conversion and "
                              "demultiplexing for run {}".format(run.id)))


### PR DESCRIPTION
Ha! That was tricky to see... I was not calling the function, but checking if it existed, which was always returning true, which was making TACA to start demultiplexing even if the run was not finished...

`self.merge()` because its critical