### PR TITLE
HOTFIX: Transferring a run 

### DIFF
--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -48,45 +48,44 @@ def transfer_run(run, analysis=True):
     :param str run: Run directory
     :param bool analysis: Trigger analysis on remote server
     """
-    with chdir(run):
-        command_line = ['rsync', '-av']
-        # Add R/W permissions to the group
-        command_line.append('--chmod=g+rw')
-        # rsync works in a really funny way, if you don't understand this, refer to
-        # this note: http://silentorbit.com/notes/2013/08/rsync-by-extension/
-        command_line.append("--include=*/")
-        for to_include in CONFIG['analysis']['analysis_server']['sync']['include']:
-            command_line.append("--include={}".format(to_include))
-        command_line.extend(["--exclude=*", "--prune-empty-dirs"])
-        r_user = CONFIG['analysis']['analysis_server']['user']
-        r_host = CONFIG['analysis']['analysis_server']['host']
-        r_dir = CONFIG['analysis']['analysis_server']['sync']['data_archive']
-        remote = "{}@{}:{}".format(r_user, r_host, r_dir)
-        command_line.extend([run, remote])
+    command_line = ['rsync', '-av']
+    # Add R/W permissions to the group
+    command_line.append('--chmod=g+rw')
+    # rsync works in a really funny way, if you don't understand this, refer to
+    # this note: http://silentorbit.com/notes/2013/08/rsync-by-extension/
+    command_line.append("--include=*/")
+    for to_include in CONFIG['analysis']['analysis_server']['sync']['include']:
+        command_line.append("--include={}".format(to_include))
+    command_line.extend(["--exclude=*", "--prune-empty-dirs"])
+    r_user = CONFIG['analysis']['analysis_server']['user']
+    r_host = CONFIG['analysis']['analysis_server']['host']
+    r_dir = CONFIG['analysis']['analysis_server']['sync']['data_archive']
+    remote = "{}@{}:{}".format(r_user, r_host, r_dir)
+    command_line.extend([run, remote])
 
-        # Create temp file indicating that the run is being transferred
-        open('transferring', 'w').close()
-        started = ("Started transfer of run {} on {}"
-                   .format(os.path.basename(run), datetime.now()))
-        logger.info(started)
-        # In this particular case we want to capture the exception because we want
-        # to delete the transfer file
-        try:
-            misc.call_external_command(command_line, with_log_files=True)
-        except subprocess.CalledProcessError as exception:
-            os.remove('transferring')
-            raise exception
-
-        t_file = os.path.join(CONFIG['analysis']['status_dir'], 'transfer.tsv')
-        logger.info('Adding run {} to {}'
-                    .format(os.path.basename(run), t_file))
-        with open(t_file, 'a') as tranfer_file:
-            tsv_writer = csv.writer(tranfer_file, delimiter='\t')
-            tsv_writer.writerow([os.path.basename(run), str(datetime.now())])
+    # Create temp file indicating that the run is being transferred
+    open('transferring', 'w').close()
+    started = ("Started transfer of run {} on {}"
+               .format(os.path.basename(run), datetime.now()))
+    logger.info(started)
+    # In this particular case we want to capture the exception because we want
+    # to delete the transfer file
+    try:
+        misc.call_external_command(command_line, with_log_files=True)
+    except subprocess.CalledProcessError as exception:
         os.remove('transferring')
+        raise exception
 
-        if analysis:
-            trigger_analysis(run)
+    t_file = os.path.join(CONFIG['analysis']['status_dir'], 'transfer.tsv')
+    logger.info('Adding run {} to {}'
+                .format(os.path.basename(run), t_file))
+    with open(t_file, 'a') as tranfer_file:
+        tsv_writer = csv.writer(tranfer_file, delimiter='\t')
+        tsv_writer.writerow([os.path.basename(run), str(datetime.now())])
+    os.remove('transferring')
+
+    if analysis:
+        trigger_analysis(run)
 
 
 def trigger_analysis(run_id):

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -327,10 +327,19 @@ def run_preprocessing(run):
             # even more specific like cycle or something
             logger.info('Run {} is not finished yet'.format(run.id))
 
+    data_dirs = CONFIG.get('analysis').get('data_dirs')
     if run:
-        _process(Run(run))
+        run_dir = None if not os.path.isabs(run) else run
+        if not run_dir:
+            for data_dir in data_dirs:
+                if os.path.exists(os.path.join(data_dir, run)):
+                    run_dir = os.path.join(data_dir, run)
+                    break
+        if run_dir:
+            _process(Run(run))
+        else:
+            raise RuntimeError("Run {} not found in {}".format(run, ', '.join(data_dirs)))
     else:
-        data_dirs = CONFIG.get('analysis').get('data_dirs')
         for data_dir in data_dirs:
             runs = glob.glob(os.path.join(data_dir, '1*XX'))
             for _run in runs:

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -327,19 +327,10 @@ def run_preprocessing(run):
             # even more specific like cycle or something
             logger.info('Run {} is not finished yet'.format(run.id))
 
-    data_dirs = CONFIG.get('analysis').get('data_dirs')
     if run:
-        run_dir = None if not os.path.isabs(run) else run
-        if not run_dir:
-            for data_dir in data_dirs:
-                if os.path.exists(os.path.join(data_dir, run)):
-                    run_dir = os.path.join(data_dir, run)
-                    break
-        if run_dir:
-            _process(Run(run))
-        else:
-            raise RuntimeError("Run {} not found in {}".format(run, ', '.join(data_dirs)))
+        _process(Run(run))
     else:
+        data_dirs = CONFIG.get('analysis').get('data_dirs')
         for data_dir in data_dirs:
             runs = glob.glob(os.path.join(data_dir, '1*XX'))
             for _run in runs:


### PR DESCRIPTION
Fix transferring run bug. Tack @vezzi

Can't really spot when I did introduce this bug, but the thing is that the `rsync` command was being constructed like this:

```
(test)hiseq.bioinfo@preproc1:/srv/illumina/HiSeq_X_data$ cat 150519_ST-E00214_0036_BH3CWHCCXX/rsync.err
rsync: link_stat "/srv/illumina/HiSeq_X_data/150519_ST-E00214_0036_BH3CWHCCXX/150519_ST-E00214_0036_BH3CWHCCXX" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1039) [sender=3.0.6]
```

Appending the run directory when you're already inside it, so basically no need to `chdir`