### PR TITLE
rename the undetermined if the lane is not pooled, even if qc fails

### DIFF
--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -180,7 +180,7 @@ def post_qc(run, qc_file, status):
     """
     already_seen=False
     runname=os.path.basename(os.path.abspath(run))
-    shortrun=runname.split('_')[0] + unname.split('_')[-1]
+    shortrun=runname.split('_')[0] + runname.split('_')[-1]
     with open(qc_file, 'ab+') as f:
         f.seek(0)
         for row in f:

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -180,7 +180,7 @@ def post_qc(run, qc_file, status):
     """
     already_seen=False
     runname=os.path.basename(os.path.abspath(run))
-    shortrun=runname.split('_')[0] + runname.split('_')[-1]
+    shortrun=runname.split('_')[0] + '_' +runname.split('_')[-1]
     with open(qc_file, 'ab+') as f:
         f.seek(0)
         for row in f:

--- a/taca/analysis/cli.py
+++ b/taca/analysis/cli.py
@@ -27,6 +27,6 @@ def transfer(rundir, analysis):
 
 @analysis.command()
 @click.argument('rundir')
-def update-db(rundir):
+def updatedb(rundir):
     """saves the run to statusdb"""
     an.upload_to_statusdb(rundir)

--- a/taca/utils/undetermined.py
+++ b/taca/utils/undetermined.py
@@ -41,10 +41,10 @@ def check_undetermined_status(run, und_tresh=10, q30_tresh=75, freq_tresh=40, po
         workable_lanes=get_workable_lanes(run, dex_status)
         for lane in workable_lanes:
             if is_unpooled_lane(ss,lane):
+                rename_undet(run, lane, samples_per_lane)
                 if check_index_freq(run,lane, freq_tresh):
                     if lb :
                         if first_qc_check(lane,lb, und_tresh, q30_tresh):
-                            rename_undet(run, lane, samples_per_lane)
                             link_undet_to_sample(run, lane, path_per_lane)
                             status=True
                         else:
@@ -178,7 +178,7 @@ def check_index_freq(run, lane, freq_tresh):
 
     else:
         open(os.path.join(run, dmux_folder,'index_count_L{}.tsv'.format(lane)), 'a').close()
-        for fastqfile in glob.glob(os.path.join(run, dmux_folder, 'Undetermined_*_L0?{}_R1*'.format(lane))):
+        for fastqfile in glob.glob(os.path.join(run, dmux_folder, '*Undetermined*_L0?{}_R1*'.format(lane))):
             logger.info("working on {}".format(fastqfile))
             zcat=subprocess.Popen(['zcat', fastqfile], stdout=subprocess.PIPE)
             sed=subprocess.Popen(['sed', '-n', "1~4p"],stdout=subprocess.PIPE, stdin=zcat.stdout)


### PR DESCRIPTION
I don't really like that, because the renaming is rather... cryptic, let's say. 
Here is an example : 

Undetermined\_**S0**_L004_R1_001.fastq.gz
becomes
**P1775_171**_Undetermined_L0**1**4_R1_001.fastq.gz

At your own risks.