### PR TITLE
Hotfix/validate transfer bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _build
 *.log
 .DS*
 .vagrant/
+.idea/

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.1.9'
+__version__ = '0.1.10'

--- a/taca/utils/transfer.py
+++ b/taca/utils/transfer.py
@@ -140,6 +140,7 @@ class RsyncAgent(TransferAgent):
             src_path=src_path,
             dest_path=dest_path,
             opts=opts or self.DEFAULT_OPTS,
+            validate=validate,
             **kwargs)
         self.remote_host = remote_host
         self.remote_user = remote_user

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import tempfile
 import unittest
 
 from datetime import datetime
@@ -42,7 +43,7 @@ class TestTracker(unittest.TestCase):
             |__ RunInfo.xml
             |__ RTAComplete.txt
         """
-        self.tmp_dir = 'tmp'
+        self.tmp_dir = os.path.join(tempfile.mkdtemp(), 'tmp')
         self.transfer_file = os.path.join(self.tmp_dir, 'transfer.tsv')
 
         running = os.path.join(self.tmp_dir, '141124_RUNNING_FCIDXX')


### PR DESCRIPTION
- fixed a bug where the setting to validate the delivered file after rsync transfer against the list of digests was not being properly set