### PR TITLE
Creates records on sample instead of project level

### DIFF
--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -221,10 +221,10 @@ def error_emailer(flag, info):
     #no_samplesheet: A run was moved back due to QC/BP-Fail. Some samples still passed
     #failed_run: Samplesheet for a given project couldn't be found
     
-    body='Whazzup! TACA is behaving mad whack yo!\n'
-    body+='The playa disrespectin us is: '
+    body='TACA has encountered an issue that might be worth investigating\n'
+    body+='The offending entry is: '
     body+= info
-    body+='\nBring down the hammer on tha fool. \n\nREPRESENT!\n'
+    body+='\n\nSincerely, TACA'
 
     if (flag == 'no_samplesheet'):
         subject='ERROR, Samplesheet error'

--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -10,8 +10,7 @@ from csv import DictReader
 from taca.utils.config import CONFIG
 from flowcell_parser.classes import SampleSheetParser
 from collections import defaultdict
-from lib2to3.tests.support import proj_dir
-from taca.utils.misc import send_mail, hours_old
+from taca.utils.misc import send_mail
 
 logger = logging.getLogger(__name__)
 

--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -75,7 +75,7 @@ def update_statusdb(run_dir):
     #Construction and sending of individual records
     if p == 'UNKNOWN':
         obj={'run_id':run_name}
-        logger.info("INVALID SAMPLSHEET, CHECK {} FORMED AT {}".format(run_name, valueskey))
+        logger.info("INVALID SAMPLESHEET, CHECK {} FORMED AT {}".format(run_name, valueskey))
         db.save(obj)
         #print obj
     else:
@@ -180,8 +180,8 @@ def get_ss_projects(run_dir):
         csvf=open(FCID_samplesheet_origin, 'rU')
         data=DictReader(csvf)
 
+    proj, lane, sample = False
     for d in data:
-        proj, lane, sample = False
         for v in d.values():
             #if project is found
             if proj_pattern.search(v):


### PR DESCRIPTION
`get_ss_project` has been changed to collect `proj`, `fc`, `lane` and sample name instead of just proj name.
Output to couchdb is a bit crude (one entry per sample) but could easily be aggregated into less records if needed.