### PR TITLE
Removing automate soflinking of Undet in X-runs

### DIFF
--- a/taca/illumina/HiSeqX_Runs.py
+++ b/taca/illumina/HiSeqX_Runs.py
@@ -128,7 +128,6 @@ class HiSeqX_Run(Run):
 
 
     def check_QC(self):
-        #TODO rewrite this using Illumina computed Undetermined files
         run_dir = self.run_dir
         dmux_folder = self.demux_dir
 
@@ -168,8 +167,9 @@ class HiSeqX_Run(Run):
             max_frequency_most_represented_und  = max_frequency_most_represented_und_index_pooled_lane
             #distinguish the case between Pooled and Unpooled lanes, for unpooled lanes rename the Undetemriend file
             if self.is_unpooled_lane(lane):
+                ##DO NOT ADD UNDET BY DEFAULT TO SAMPLES
                 #rename undetermiend, in this way PIPER will be able to use them
-                self._rename_undet(lane, samples_per_lane)
+                ##self._rename_undet(lane, samples_per_lane)
                 max_percentage_undetermined_indexes = max_percentage_undetermined_indexes_unpooled_lane
                 max_frequency_most_represented_und  = max_frequency_most_represented_und_index_unpooled_lane
                 logger.info("linking undetermined lane {} to sample".format(lane))

--- a/taca/illumina/HiSeqX_Runs.py
+++ b/taca/illumina/HiSeqX_Runs.py
@@ -169,8 +169,9 @@ class HiSeqX_Run(Run):
             if self.is_unpooled_lane(lane):
                 ##DO NOT ADD UNDET BY DEFAULT TO SAMPLES
                 #rename undetermiend, in this way PIPER will be able to use them
-                ##self._rename_undet(lane, samples_per_lane)
+                self._rename_undet(lane, samples_per_lane)
                 ##logger.info("linking undetermined lane {} to sample".format(lane))
+                ##but do not soft link them
                 #misc.link_undet_to_sample(run_dir, dmux_folder, lane, path_per_lane)
                 max_percentage_undetermined_indexes = max_percentage_undetermined_indexes_unpooled_lane
                 max_frequency_most_represented_und  = max_frequency_most_represented_und_index_unpooled_lane

--- a/taca/illumina/HiSeqX_Runs.py
+++ b/taca/illumina/HiSeqX_Runs.py
@@ -170,10 +170,11 @@ class HiSeqX_Run(Run):
                 ##DO NOT ADD UNDET BY DEFAULT TO SAMPLES
                 #rename undetermiend, in this way PIPER will be able to use them
                 ##self._rename_undet(lane, samples_per_lane)
+                ##logger.info("linking undetermined lane {} to sample".format(lane))
+                #misc.link_undet_to_sample(run_dir, dmux_folder, lane, path_per_lane)
                 max_percentage_undetermined_indexes = max_percentage_undetermined_indexes_unpooled_lane
                 max_frequency_most_represented_und  = max_frequency_most_represented_und_index_unpooled_lane
-                logger.info("linking undetermined lane {} to sample".format(lane))
-                misc.link_undet_to_sample(run_dir, dmux_folder, lane, path_per_lane)
+            
             
             if self.check_undetermined_reads(lane, max_percentage_undetermined_indexes):
                 if self.check_maximum_undertemined_freq(lane, max_frequency_most_represented_und):


### PR DESCRIPTION
We no longer automatically softlink undetermined reads when a single sample per lane is run.
In case we need to use undet we will manually softlink them.