### PR TITLE
copy demulti stat to mfs

### DIFF
--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -204,12 +204,12 @@ def run_preprocessing(run, force_trasfer=True):
                 _upload_to_statusdb(run)
             #copy demultiplex stat file to shard file system for LIMS purpose
             try:
-                mfs_dest = os.path.join(CONFIG['mfs_path'],"{}_data".format(_run_type(run).lower()),run.id, 'laneBarcode.html')
-                logger.info('Copying demultiplex stat for run {} to {}'.format(run.id, CONFIG[]))
+                mfs_dest = os.path.join(CONFIG['mfs_path'],"{}_data".format(_run_type(run).lower()),run.id)
+                logger.info('Copying demultiplex stat for run {} to {}'.format(run.id, mfs_dest))
                 if not os.path.exists(mfs_dest):
                     os.mkdir(mfs_dest)
                 demulti_stat_src = os.path.join(run.run_dir, run.demux_dir, 'Reports', 'html', run.flowcell_id, 'all', 'all', 'all', 'laneBarcode.html')
-                copyfile(demulti_stat_src, mfs_dest)
+                copyfile(demulti_stat_src, os.path.join(mfs_dest, 'laneBarcode.html'))
             except:
                 logger.warn('Could not copy demultiplex stat file for run {}'.format(run.id))
             #tranfer data to uppmax

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -11,6 +11,7 @@ from taca.illumina.HiSeqX_Runs import HiSeqX_Run
 from taca.illumina.HiSeq_Runs import HiSeq_Run
 from taca.illumina.MiSeq_Runs import MiSeq_Run
 from taca.utils.config import CONFIG
+from shutil import copyfile
 
 import flowcell_parser.db as fcpdb
 from   flowcell_parser.classes import RunParametersParser
@@ -201,6 +202,17 @@ def run_preprocessing(run, force_trasfer=True):
             #upload to statusDB
             if 'statusdb' in CONFIG:
                 _upload_to_statusdb(run)
+            #copy demultiplex stat file to shard file system for LIMS purpose
+            try:
+                mfs_dest = os.path.join(CONFIG['mfs_path'],"{}_data".format(_run_type(run).lower()),run.id, 'laneBarcode.html')
+                logger.info('Copying demultiplex stat for run {} to {}'.format(run.id, CONFIG[]))
+                if not os.path.exists(mfs_dest):
+                    os.mkdir(mfs_dest)
+                demulti_stat_src = os.path.join(run.run_dir, run.demux_dir, 'Reports', 'html', run.flowcell_id, 'all', 'all', 'all', 'laneBarcode.html')
+                copyfile(demulti_stat_src, mfs_dest)
+            except:
+                logger.warn('Could not copy demultiplex stat file for run {}'.format(run.id))
+            #tranfer data to uppmax
             logger.info('Transferring run {} to {} into {}'
                                 .format(run.id,
                                 run.CONFIG['analysis_server']['host'],

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -141,7 +141,7 @@ def cleanup_swestore(days, dry_run=False):
 
     :param int days: Threshold days to check and remove
     """
-    days = check_days('swestore', days, config)
+    days = check_days('swestore', days, CONFIG)
     if not days:
         return
     runs = filesystem.list_runs_in_swestore(path=CONFIG.get('cleanup').get('swestore').get('root'))
@@ -162,7 +162,7 @@ def cleanup_uppmax(site, days, dry_run=False):
     :param str site: site where the cleanup should be performed
     :param int days: number of days to check for closed projects
     """
-    days = check_days(site, days, config)
+    days = check_days(site, days, CONFIG)
     if not days:
         return
     root_dir = CONFIG.get('cleanup').get(site).get('root')


### PR DESCRIPTION
Soon `Bcl conversion` step will be added for `HiSeqX` runs and also `TACA` will be used for `HiSeq` for demultiplexing, so LIMS epp will need a file to look at in `mfs` filesystem. 