### PR TITLE
Quick fix to make sure poor Samplesheets wont break taca

### DIFF
--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -178,8 +178,8 @@ def get_ss_projects(run_dir):
             logger.warn("Cannot initialize SampleSheetParser for {}. Most likely due to poor comma separation".format(run_dir))
             return []
         if 'Description' in ss_reader.header and ss_reader.header['Description'] not in ['Production', 'Application']:
-                logger.warn("Run {} detected as a non platform MiSeq run. Disregarding it.".format(run_dir))
-                return []
+            logger.warn("Run {} detected as a non platform MiSeq run. Disregarding it.".format(run_dir))
+            return []
     else:
         try:
             csvf=open(FCID_samplesheet_origin, 'rU')

--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -171,14 +171,23 @@ def get_ss_projects(run_dir):
                     logger.warn("Cannot locate the samplesheet for run {}".format(run_dir))
                     return ['UNKNOWN']
 
-        ss_reader=SampleSheetParser(FCID_samplesheet_origin)
-        if 'Description' in ss_reader.header and ss_reader.header['Description'] not in ['Production', 'Application']:
-            #This is a non platform MiSeq run. Disregard it.
+        try:
+            ss_reader=SampleSheetParser(FCID_samplesheet_origin)
+            if ss_reader.header['Description'] not in ['Production', 'Application']:
+                #This is a non platform MiSeq run. Disregard it.
+                return []
+            data=ss_reader.data
+        except:
+            logger.warn("Cannot initialize SampleSheetParser for {}. Most likely due to poor comma separation".format(run_dir))
             return []
-        data=ss_reader.data
     else:
-        csvf=open(FCID_samplesheet_origin, 'rU')
-        data=DictReader(csvf)
+        try:
+            csvf=open(FCID_samplesheet_origin, 'rU')
+            data=DictReader(csvf)
+        except:
+            logger.warn("Cannot initialize DictReader for {}. Most likely due to poor comma separation".format(run_dir))
+            return []
+            
     proj_n_sample = False
     lane = False
     for d in data:

--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -173,13 +173,13 @@ def get_ss_projects(run_dir):
 
         try:
             ss_reader=SampleSheetParser(FCID_samplesheet_origin)
-            if ss_reader.header['Description'] not in ['Production', 'Application']:
-                #This is a non platform MiSeq run. Disregard it.
-                return []
             data=ss_reader.data
         except:
             logger.warn("Cannot initialize SampleSheetParser for {}. Most likely due to poor comma separation".format(run_dir))
             return []
+        if 'Description' in ss_reader.header and ss_reader.header['Description'] not in ['Production', 'Application']:
+                logger.warn("Run {} detected as a non platform MiSeq run. Disregarding it.".format(run_dir))
+                return []
     else:
         try:
             csvf=open(FCID_samplesheet_origin, 'rU')


### PR DESCRIPTION
I prefer returning [] rather than sys.exit or similar since the entire program shouldn't stop from just one bad apple.