### PR TITLE
Use "hours" to consider old runs

### DIFF
--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -5,9 +5,9 @@ from taca.storage import storage as st
 from taca.utils import misc
         
 @click.group()
-@click.option('-d', '--days', type=click.INT,
+@click.option('-d', '--days', type=click.IntRange(min=1),
               help="Days to consider as thershold, should not be combined with option '--hours'")
-@click.option('-h', '--hours', type=click.INT,
+@click.option('-h', '--hours', type=click.IntRange(min=1),
               help="Hours to consider as thershold, should not be combined with option '--days'")
 @click.option('-r', '--run', type=click.Path(exists=True))
 @click.pass_context

--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -2,14 +2,16 @@
 """
 import click
 from taca.storage import storage as st
-
-
+from taca.utils import misc
+        
 @click.group()
-@click.option('-d', '--days', type=click.INT, help="Days to consider as thershold, this should not be used \
-                                                    if 'cleanup' sub-command is called with '--hours'")
+@click.option('-d', '--days', type=click.INT,
+              help="Days to consider as thershold, should not be combined with option '--hours'")
+@click.option('-h', '--hours', type=click.INT,
+              help="Hours to consider as thershold, should not be combined with option '--days'")
 @click.option('-r', '--run', type=click.Path(exists=True))
 @click.pass_context
-def storage(ctx, days, run):
+def storage(ctx, days, hours, run):
 	""" Storage management methods and utilities """
 	pass
 
@@ -35,18 +37,16 @@ def archive(ctx, backend, max_runs, force, compress_only):
 @click.option('-s','--site', type=click.Choice(['swestore','archive','illumina','analysis','nas','processing-server']),
               required=True, help='Site to perform cleanup')
 @click.option('-n','--dry-run', is_flag=True, help='Perform dry run i.e. Executes nothing but log')
-@click.option('--hours', type=click.INT, help="Hours to consider as thershold, this should \
-                                               not be used if '--days' of 'storage' group is used")
 @click.pass_context
-def cleanup(ctx, site, dry_run, hours):
+def cleanup(ctx, site, dry_run):
     """ Do appropriate cleanup on the given site i.e. NAS/processing servers/UPPMAX """
     params = ctx.parent.params
-    days = params.get('days')
+    seconds = misc.to_seconds(days=params.get('days'), hours=params.get('hours'))
     if site == 'nas':
-        st.cleanup_nas(days, hours)
+        st.cleanup_nas(seconds)
     if site == 'processing-server':
-        st.cleanup_processing(days)
+        st.cleanup_processing(seconds)
     if site == 'swestore':
         st.cleanup_swestore(days, dry_run)
     if site in ['illumina','analysis','archive']:
-        st.cleanup_uppmax(site, days, dry_run)
+        st.cleanup_uppmax(site, seconds, dry_run)

--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -5,7 +5,8 @@ from taca.storage import storage as st
 
 
 @click.group()
-@click.option('-d', '--days', type=click.INT, help="Days to consider as thershold")
+@click.option('-d', '--days', type=click.INT, help="Days to consider as thershold, this should not be used \
+                                                    if 'cleanup' sub-command is called with '--hours'")
 @click.option('-r', '--run', type=click.Path(exists=True))
 @click.pass_context
 def storage(ctx, days, run):
@@ -34,13 +35,15 @@ def archive(ctx, backend, max_runs, force, compress_only):
 @click.option('-s','--site', type=click.Choice(['swestore','archive','illumina','analysis','nas','processing-server']),
               required=True, help='Site to perform cleanup')
 @click.option('-n','--dry-run', is_flag=True, help='Perform dry run i.e. Executes nothing but log')
+@click.option('--hours', type=click.INT, help="Hours to consider as thershold, this should \
+                                               not be used if '--days' of 'storage' group is used")
 @click.pass_context
-def cleanup(ctx, site, dry_run):
+def cleanup(ctx, site, dry_run, hours):
     """ Do appropriate cleanup on the given site i.e. NAS/processing servers/UPPMAX """
     params = ctx.parent.params
     days = params.get('days')
     if site == 'nas':
-        st.cleanup_nas(days)
+        st.cleanup_nas(days, hours)
     if site == 'processing-server':
         st.cleanup_processing(days)
     if site == 'swestore':

--- a/taca/storage/cli.py
+++ b/taca/storage/cli.py
@@ -17,24 +17,21 @@ def storage(ctx, days, hours, run):
 
 # Storage subcommands
 @storage.command()
-@click.option('--backend', type=click.Choice(['swestore']), required=True,
-              help='Long term storage backend')
+@click.option('--backend', required=True, help='Long term storage backend')
 @click.option('-m','--max-runs', type=click.INT, help='Limit the number of runs to be archived simultaneously')
 @click.option('-f', '--force', is_flag=True, help=("Force archiving even if the run "
 												   "is not complete (not RTAComplete.txt file found)"))
 @click.option('-c', '--compress-only', is_flag=True, help='Only compress the run without archiving it')
 @click.pass_context
 def archive(ctx, backend, max_runs, force, compress_only):
-    """ Archive old runs to SWESTORE
+    """ Archive old runs
 	"""
-    params = ctx.parent.params
-    if backend == 'swestore':
-        st.archive_to_swestore(days=params.get('days'), run=params.get('run'), max_runs=max_runs,
-							   force=force, compress_only=compress_only)
+    # to be implemented yet with new method, old one is deprecated
+    raise NotImplementedError
 
 
 @storage.command()
-@click.option('-s','--site', type=click.Choice(['swestore','archive','illumina','analysis','nas','processing-server']),
+@click.option('-s','--site', type=click.Choice(['archive','illumina','analysis','nas','processing-server']),
               required=True, help='Site to perform cleanup')
 @click.option('-n','--dry-run', is_flag=True, help='Perform dry run i.e. Executes nothing but log')
 @click.pass_context
@@ -46,7 +43,5 @@ def cleanup(ctx, site, dry_run):
         st.cleanup_nas(seconds)
     if site == 'processing-server':
         st.cleanup_processing(seconds)
-    if site == 'swestore':
-        st.cleanup_swestore(days, dry_run)
     if site in ['illumina','analysis','archive']:
         st.cleanup_uppmax(site, seconds, dry_run)

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -27,9 +27,11 @@ def cleanup_nas(days, hours):
     """
     #only either days or hours should be speciefied, but atleast one should be specified
     if days and hours:
-        raise SystemExit('Both "--days" and "--hours" was specified, use only either of them')
+        logger.error('Both "--days" and "--hours" was specified, use only either of them')
+        raise SystemExit
     elif not days and not hours:
-        raise SystemExit('Use either "--days" or "--hours" option to set a threshold for considering old runs')
+        logger.error('Use either "--days" or "--hours" option to set a threshold for considering old runs')
+        raise SystemExit
     elif days and not hours:
         # 1 day == 60*60*24 seconds --> 86400
         threshold_seconds = 86400 * days

--- a/taca/storage/storage.py
+++ b/taca/storage/storage.py
@@ -17,8 +17,7 @@ from taca.utils import filesystem, misc
 logger = logging.getLogger(__name__)
 
 # This is used by many of the functions in this module
-finished_run_indicator = CONFIG.get('storage', {}).get('finished_run_indicator',
-                                                   'RTAComplete.txt')
+finished_run_indicator = CONFIG.get('storage', {}).get('finished_run_indicator', 'RTAComplete.txt')
 
 def cleanup_nas(seconds):
     """Will move the finished runs in NASes to nosync directory.
@@ -39,26 +38,13 @@ def cleanup_nas(seconds):
                         logger.info('{} file exists but is not older than given time, skipping run {}'.format(
                                     finished_run_indicator, run))
 
-## this method is not used anymore and will be changed in future (real soon)
+
 def cleanup_processing(seconds):
     """Cleanup runs in processing server.
 
     :param int seconds: Days/hours converted as second to consider a run to be old
     """
-    transfer_file = os.path.join(CONFIG.get('preprocessing', {}).get('status_dir'), 'transfer.tsv')
     try:
-        #Move finished runs to nosync
-        for data_dir in CONFIG.get('storage').get('data_dirs'):
-            logger.info('Moving old runs in {}'.format(data_dir))
-            with filesystem.chdir(data_dir):
-                for run in [r for r in os.listdir(data_dir) if re.match(filesystem.RUN_RE, r)]:
-                    if filesystem.is_in_file(transfer_file, run):
-                        logger.info('Moving run {} to nosync directory'
-                                    .format(os.path.basename(run)))
-                        shutil.move(run, 'nosync')
-                    else:
-                        logger.info(("Run {} has not been transferred to the analysis "
-                            "server yet, not archiving".format(run)))
         #Remove old runs from archiving dirs
         for archive_dir in CONFIG.get('storage').get('archive_dirs').values():
             logger.info('Removing old runs in {}'.format(archive_dir))
@@ -72,7 +58,6 @@ def cleanup_processing(seconds):
                         else:
                             logger.info('{} file exists but is not older than given time, skipping run {}'.format(
                                         finished_run_indicator, run))
-
     except IOError:
         sbj = "Cannot archive old runs in processing server"
         msg = ("Could not find transfer.tsv file, so I cannot decide if I should "
@@ -82,72 +67,6 @@ def cleanup_processing(seconds):
             cnt = "{}@localhost".format(getpass.getuser())
         logger.error(msg)
         misc.send_mail(sbj, msg, cnt)
-
-## this method is not used anymore and will be changed in future (real soon)
-def archive_to_swestore(days, run=None, max_runs=None, force=False, compress_only=False):
-    """Send runs (as archives) in NAS nosync to swestore for backup
-
-    :param int days: number fo days to check threshold
-    :param str run: specific run to send swestore
-    :param int max_runs: number of runs to be processed simultaneously
-    :param bool force: Force the archiving even if the run is not complete
-    :param bool compress_only: Compress the run without sending it to swestore
-    """
-    # If the run is specified in the command line, check that exists and archive
-    if run:
-        run = os.path.basename(run)
-        base_dir = os.path.dirname(run)
-        if re.match(filesystem.RUN_RE, run):
-            # If the parameter is not an absolute path, find the run in the archive_dirs
-            if not base_dir:
-                for archive_dir in CONFIG.get('storage').get('archive_dirs'):
-                    if os.path.exists(os.path.join(archive_dir, run)):
-                        base_dir = archive_dir
-            if not os.path.exists(os.path.join(base_dir, run)):
-                logger.error(("Run {} not found. Please make sure to specify "
-                              "the absolute path or relative path being in "
-                              "the correct directory.".format(run)))
-            else:
-                with filesystem.chdir(base_dir):
-                    _archive_run((run, days, force, compress_only))
-        else:
-            logger.error("The name {} doesn't look like an Illumina run"
-                         .format(os.path.basename(run)))
-    # Otherwise find all runs in every data dir on the nosync partition
-    else:
-        logger.info("Archiving old runs to SWESTORE")
-        for to_send_dir in CONFIG.get('storage').get('archive_dirs'):
-            logger.info('Checking {} directory'.format(to_send_dir))
-            with filesystem.chdir(to_send_dir):
-                to_be_archived = [r for r in os.listdir(to_send_dir)
-                                  if re.match(filesystem.RUN_RE, r)
-                                  and not os.path.exists("{}.archiving".format(r.split('.')[0]))]
-                if to_be_archived:
-                    pool = Pool(processes=len(to_be_archived) if not max_runs else max_runs)
-                    pool.map_async(_archive_run, ((run, days, force, compress_only) for run in to_be_archived))
-                    pool.close()
-                    pool.join()
-                else:
-                    logger.info('No old runs to be archived')
-
-## this method is not used anymore and will be changed/removed in future (real soon)
-def cleanup_swestore(days, dry_run=False):
-    """Remove archived runs from swestore
-
-    :param int days: Threshold days to check and remove
-    """
-    days = check_days('swestore', days, CONFIG)
-    if not days:
-        return
-    runs = filesystem.list_runs_in_swestore(path=CONFIG.get('cleanup').get('swestore').get('root'))
-    for run in runs:
-        date = run.split('_')[0]
-        if misc.days_old(date) > days:
-            if dry_run:
-                logger.info('Will remove file {} from swestore'.format(run))
-                continue
-            misc.call_external_command('irm -f {}'.format(run))
-            logger.info('Removed file {} from swestore'.format(run))
 
 
 def cleanup_uppmax(site, seconds, dry_run=False):
@@ -229,59 +148,6 @@ def cleanup_uppmax(site, seconds, dry_run=False):
 #############################################################
 # Class helper methods, not exposed as commands/subcommands #
 #############################################################
-## this method is not used anymore and will be changed/removed in future (real soon)
-def _archive_run((run, days, force, compress_only)):
-    """ Archive a specific run to swestore
-
-    :param str run: Run directory
-    :param int days: Days to consider a run old
-    :param bool force: Force the archiving even if the run is not complete
-    :param bool compress_only: Only compress the run without sending it to swestore
-    """
-
-    def _send_to_swestore(f, dest, remove=True):
-        """ Send file to swestore checking adler32 on destination and eventually
-        removing the file from disk
-
-        :param str f: File to remove
-        :param str dest: Destination directory in Swestore
-        :param bool remove: If True, remove original file from source
-        """
-        if not filesystem.is_in_swestore(f):
-            logger.info("Sending {} to swestore".format(f))
-            misc.call_external_command('iput -R swestoreArchCacheResc -P {file} {dest}'.format(file=f, dest=dest),
-                    with_log_files=True, prefix=f.replace('.tar.bz2',''), log_dir="swestore_logs")
-            logger.info('Run {} sent to swestore.'.format(f))
-            if remove:
-                logger.info('Removing run'.format(f))
-                os.remove(f)
-        else:
-            logger.warn('Run {} is already in Swestore, not sending it again nor removing from the disk'.format(f))
-
-    # Create state file to say that the run is being archived
-    open("{}.archiving".format(run.split('.')[0]), 'w').close()
-    if run.endswith('bz2'):
-        if os.stat(run).st_mtime < time.time() - (86400 * days):
-            _send_to_swestore(run, CONFIG.get('storage').get('irods').get('irodsHome'))
-        else:
-            logger.info("Run {} is not {} days old yet. Not archiving".format(run, str(days)))
-    else:
-        rta_file = os.path.join(run, finished_run_indicator)
-        if not os.path.exists(rta_file) and not force:
-            logger.warn(("Run {} doesn't seem to be completed and --force option was "
-                      "not enabled, not archiving the run".format(run)))
-        if force or (os.path.exists(rta_file) and os.stat(rta_file).st_mtime < time.time() - (86400 * days)):
-            logger.info("Compressing run {}".format(run))
-            # Compress with pbzip2
-            misc.call_external_command('tar --use-compress-program=pbzip2 -cf {run}.tar.bz2 {run}'.format(run=run))
-            logger.info('Run {} successfully compressed! Removing from disk...'.format(run))
-            shutil.rmtree(run)
-            if not compress_only:
-                _send_to_swestore('{}.tar.bz2'.format(run), CONFIG.get('storage').get('irods').get('irodsHome'))
-        else:
-            logger.info("Run {} is not completed or is not {} days old yet. Not archiving".format(run, str(days)))
-    os.remove("{}.archiving".format(run.split('.')[0]))
-
 
 def get_closed_projects(projs, pj_con, seconds):
     """Takes list of project and gives project list that are closed
@@ -333,3 +199,128 @@ def check_default(site, seconds, config):
             return seconds
         else:
             return None
+
+
+############################################################
+#######             DEPRECATED METHODS               #######
+############################################################
+## these methods are not in use anymore but kept here as it
+## might be used again in future, when world is about to end
+
+def archive_to_swestore(seconds, run=None, max_runs=None, force=False, compress_only=False):
+    """Send runs (as archives) in NAS nosync to swestore for backup
+
+    :param int seconds: Days/hours converted as seconds to check
+    :param str run: specific run to send swestore
+    :param int max_runs: number of runs to be processed simultaneously
+    :param bool force: Force the archiving even if the run is not complete
+    :param bool compress_only: Compress the run without sending it to swestore
+    """
+    # If the run is specified in the command line, check that exists and archive
+    if run:
+        run = os.path.basename(run)
+        base_dir = os.path.dirname(run)
+        if re.match(filesystem.RUN_RE, run):
+            # If the parameter is not an absolute path, find the run in the archive_dirs
+            if not base_dir:
+                for archive_dir in CONFIG.get('storage').get('archive_dirs'):
+                    if os.path.exists(os.path.join(archive_dir, run)):
+                        base_dir = archive_dir
+            if not os.path.exists(os.path.join(base_dir, run)):
+                logger.error(("Run {} not found. Please make sure to specify "
+                              "the absolute path or relative path being in "
+                              "the correct directory.".format(run)))
+            else:
+                with filesystem.chdir(base_dir):
+                    _archive_run((run, seconds, force, compress_only))
+        else:
+            logger.error("The name {} doesn't look like an Illumina run"
+                         .format(os.path.basename(run)))
+    # Otherwise find all runs in every data dir on the nosync partition
+    else:
+        logger.info("Archiving old runs to SWESTORE")
+        for to_send_dir in CONFIG.get('storage').get('archive_dirs'):
+            logger.info('Checking {} directory'.format(to_send_dir))
+            with filesystem.chdir(to_send_dir):
+                to_be_archived = [r for r in os.listdir(to_send_dir)
+                                  if re.match(filesystem.RUN_RE, r)
+                                  and not os.path.exists("{}.archiving".format(r.split('.')[0]))]
+                if to_be_archived:
+                    pool = Pool(processes=len(to_be_archived) if not max_runs else max_runs)
+                    pool.map_async(_archive_run, ((run, seconds, force, compress_only) for run in to_be_archived))
+                    pool.close()
+                    pool.join()
+                else:
+                    logger.info('No old runs to be archived')
+
+
+def _archive_run((run, seconds, force, compress_only)):
+    """ Archive a specific run to swestore
+
+    :param str run: Run directory
+    :param int seconds: Days/hours converted as seconds to check
+    :param bool force: Force the archiving even if the run is not complete
+    :param bool compress_only: Only compress the run without sending it to swestore
+    """
+
+    def _send_to_swestore(f, dest, remove=True):
+        """ Send file to swestore checking adler32 on destination and eventually
+        removing the file from disk
+
+        :param str f: File to remove
+        :param str dest: Destination directory in Swestore
+        :param bool remove: If True, remove original file from source
+        """
+        if not filesystem.is_in_swestore(f):
+            logger.info("Sending {} to swestore".format(f))
+            misc.call_external_command('iput -R swestoreArchCacheResc -P {file} {dest}'.format(file=f, dest=dest),
+                    with_log_files=True, prefix=f.replace('.tar.bz2',''), log_dir="swestore_logs")
+            logger.info('Run {} sent to swestore.'.format(f))
+            if remove:
+                logger.info('Removing run'.format(f))
+                os.remove(f)
+        else:
+            logger.warn('Run {} is already in Swestore, not sending it again nor removing from the disk'.format(f))
+
+    # Create state file to say that the run is being archived
+    open("{}.archiving".format(run.split('.')[0]), 'w').close()
+    if run.endswith('bz2'):
+        if os.stat(run).st_mtime < time.time() - seconds:
+            _send_to_swestore(run, CONFIG.get('storage').get('irods').get('irodsHome'))
+        else:
+            logger.info("Run {} is not older than given time yet. Not archiving".format(run))
+    else:
+        rta_file = os.path.join(run, finished_run_indicator)
+        if not os.path.exists(rta_file) and not force:
+            logger.warn(("Run {} doesn't seem to be completed and --force option was "
+                      "not enabled, not archiving the run".format(run)))
+        if force or (os.path.exists(rta_file) and os.stat(rta_file).st_mtime < time.time() - seconds):
+            logger.info("Compressing run {}".format(run))
+            # Compress with pbzip2
+            misc.call_external_command('tar --use-compress-program=pbzip2 -cf {run}.tar.bz2 {run}'.format(run=run))
+            logger.info('Run {} successfully compressed! Removing from disk...'.format(run))
+            shutil.rmtree(run)
+            if not compress_only:
+                _send_to_swestore('{}.tar.bz2'.format(run), CONFIG.get('storage').get('irods').get('irodsHome'))
+        else:
+            logger.info("Run {} is not completed or is not older than given time yet. Not archiving".format(run))
+    os.remove("{}.archiving".format(run.split('.')[0]))
+
+
+def cleanup_swestore(seconds, dry_run=False):
+    """Remove archived runs from swestore
+
+    :param int seconds: Days/hours converted as seconds to check
+    """
+    seconds = check_default(site, seconds, CONFIG)
+    if not seconds:
+        return
+    runs = filesystem.list_runs_in_swestore(path=CONFIG.get('cleanup').get('swestore').get('root'))
+    for run in runs:
+        date = run.split('_')[0]
+        if misc.to_seconds(misc.days_old(date)) > seconds:
+            if dry_run:
+                logger.info('Will remove file {} from swestore'.format(run))
+                continue
+            misc.call_external_command('irm -f {}'.format(run))
+            logger.info('Removed file {} from swestore'.format(run))

--- a/taca/utils/misc.py
+++ b/taca/utils/misc.py
@@ -97,6 +97,7 @@ def call_external_command_detached(cl, with_log_files=False, prefix=None):
             stderr.close()
     return p_handle
 
+
 def days_old(date, date_format="%y%m%d"):
     """ Return the number days between today and given date
 
@@ -108,6 +109,25 @@ def days_old(date, date_format="%y%m%d"):
     except ValueError:
         return None
     return time_dif.days
+
+
+def to_seconds(days=None, hours=None):
+    """ Convert given day/hours to seconds and return
+
+        :param int days: days to be converted
+        :param int hours: hours to be converted
+    """
+    #only either days or hours should be speciefied, but atleast one should be specified
+    if days and hours:
+        raise SystemExit('Both "days" and "hours" were given, use only either of them')
+    elif not days and not hours:
+        raise SystemExit('provide either "days" or "hours"')
+    elif days and not hours:
+        # 1 day == 60*60*24 seconds --> 86400
+        return 86400 * days
+    elif hours and not days:
+        # 1 hour == 60*60 seconds --> 3600
+        return 3600 * hours
 
 def hashfile(afile, hasher='sha1', blocksize=65536):
     """ Calculate the hash digest of a file with the specified algorithm and 
@@ -129,6 +149,7 @@ def hashfile(afile, hasher='sha1', blocksize=65536):
             hashobj.update(buf)
             buf = fh.read(blocksize)
     return hashobj.hexdigest()
+
     
 def query_yes_no(question, default="yes", force=False):
     """Ask a yes/no question via raw_input() and return their answer.
@@ -167,9 +188,6 @@ def query_yes_no(question, default="yes", force=False):
         else:
             sys.stdout.write("Please respond with 'yes' or 'no' "\
                                  "(or 'y' or 'n').\n")
-
-
-
 
 
 def return_unique(seq):


### PR DESCRIPTION
Now `TACA` only takes days to consider old runs, but in `NAS`es to move the data to `nosync` we need it to be even more faster than present (3 days). 