### PR TITLE
Removing PyOpenSSL requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pyyaml
 statusdb
 flowcell_parser
 beautifulsoup4
-PyOpenSSL
+#PyOpenSSL


### PR DESCRIPTION
PyOpenSSL doesn't seem to be used at the moment. Seeing how it is the most cumbersome requirement to satisfy, it'd be nice to be able to ignore it. Commenting it out as I assume it was meant for some feature that is not present.