### PR TITLE
adding underscore to make MiSeq SampleSheet look identical to HiSeq2500

### DIFF
--- a/taca/illumina/MiSeq_Runs.py
+++ b/taca/illumina/MiSeq_Runs.py
@@ -81,7 +81,7 @@ class MiSeq_Run(HiSeq_Run):
                 if 'Sample_ID' in field:
                     entry[field] ='Sample_{}'.format(value)
                 elif 'Sample_Project' in field:
-                    entry[field] = value.replace(".", "_")
+                    entry[field] = value.replace(".", "__")
                 else:
                     entry[field] = value
             if 'Lane' not in entry:


### PR DESCRIPTION
@jun-wan here it comes, with this fix MiSeq SampleSheet.csv should be identical to the HiSeq2500 one (the "__" in project name).
This should simplify things.