### PR TITLE
Removed Failed statuses from being automatically updated

### DIFF
--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'

--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -83,7 +83,7 @@ def update_statusdb(run_dir):
                             remote_doc = db[remote_id]['values']
                             remote_status = db[remote_id]['status']
                             #Only updates the listed statuses
-                            if remote_status in ['New', 'ERROR', 'Sequencing', 'Demultiplexing', 'QC-Failed', 'BP-Failed', 'Failed'] and sample_status != remote_status:
+                            if remote_status in ['New', 'ERROR', 'Sequencing', 'Demultiplexing'] and sample_status != remote_status:
                                 #Appends old entry to new. Essentially merges the two
                                 for k, v in remote_doc.items():
                                     obj['values'][k] = v


### PR DESCRIPTION
Since a run is manually set to Failed and replaced by a new entity (rather than overwriting the existing one), it makes sense for the script to not automatically change it.
This also fixes a bug where Failed runs are automatically set to New.