### PR TITLE
MFS path fix for laneBarcodes.html

### DIFF
--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -202,8 +202,7 @@ def run_preprocessing(run, force_trasfer=True, statusdb=True):
             # Copy demultiplex stats file to shared file system for LIMS purpose
             if 'mfs_path' in CONFIG:
                 try:
-                    mfs_dest = os.path.join(CONFIG['mfs_path'],
-                                        "{}_data".format(run.sequencer_type.lower()),run.id)
+                    mfs_dest = os.path.join(CONFIG['mfs_path'][run.sequencer_type.lower()],run.id)
                     logger.info('Copying demultiplex stats for run {} to {}'.format(run.id, mfs_dest))
                     if not os.path.exists(mfs_dest):
                         os.mkdir(mfs_dest)

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -200,9 +200,9 @@ def run_preprocessing(run, force_trasfer=True, statusdb=True):
                 _upload_to_statusdb(run)
 
             # Copy demultiplex stats file to shared file system for LIMS purpose
-            if 'mfs_path' in CONFIG:
+            if 'mfs_path' in CONFIG['analysis']:
                 try:
-                    mfs_dest = os.path.join(CONFIG['mfs_path'][run.sequencer_type.lower()],run.id)
+                    mfs_dest = os.path.join(CONFIG['analysis']['mfs_path'][run.sequencer_type.lower()],run.id)
                     logger.info('Copying demultiplex stats for run {} to {}'.format(run.id, mfs_dest))
                     if not os.path.exists(mfs_dest):
                         os.mkdir(mfs_dest)


### PR DESCRIPTION
So now giving individual paths in `config` file seems to be better than trying to deduct the base directory using sequencer type. Cause it is not always the same patter for all the sequencer type.

Now the config file would (or should) look like

```
mfs_path:
    hiseq: /srv/mfs/hiseq_data
    miseq: /srv/mfs/miseq_data
    hiseqx: /srv/mfs/HiSeq_X_data
```

EDIT: this section will come under `analysis` in config file