### PR TITLE
Stop using hardcoded header of samplesheets

### DIFF
--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.5.3'
+__version__ = '0.5.4'

--- a/taca/illumina/HiSeqX_Runs.py
+++ b/taca/illumina/HiSeqX_Runs.py
@@ -65,7 +65,7 @@ class HiSeqX_Run(Run):
         if not os.path.exists(samplesheet_dest):
             try:
                 with open(samplesheet_dest, 'wb') as fcd:
-                    fcd.write(_generate_clean_samplesheet(ssparser, fields_to_remove=['index2'], rename_samples=True, rename_qPCR_suffix = True, fields_qPCR=['SampleName']))
+                    fcd.write(_generate_clean_samplesheet(ssparser, fields_to_remove=['index2'], rename_samples=True, rename_qPCR_suffix = True, fields_qPCR=[ssparser.dfield_snm]))
             except Exception as e:
                 logger.error(e.text)
                 return False
@@ -298,7 +298,7 @@ class HiSeqX_Run(Run):
         d={}
         for l in ss.data:
             try:
-                d[l['Lane']]=os.path.join(run, dmux_folder, l['Project'], l['SampleID'])
+                d[l['Lane']]=os.path.join(run, dmux_folder, l[ss.dfield_proj], l[ss.dfield_sid])
             except KeyError:
                 logger.error("Can't find the path to the sample, is 'Project' in the samplesheet ?")
                 d[l['Lane']]=os.path.join(run, dmux_folder)
@@ -315,8 +315,8 @@ class HiSeqX_Run(Run):
         ss = self.runParserObj.samplesheet
         d={}
         for l in ss.data:
-            s=l['SampleName'].replace("Sample_", "").replace("-", "_")
-            d[l['Lane']]=l['SampleName']
+            s=l[ss.dfield_snm].replace("Sample_", "").replace("-", "_")
+            d[l['Lane']]=l[ss.dfield_snm]
 
         return d
 
@@ -375,17 +375,17 @@ def _generate_clean_samplesheet(ssparser, fields_to_remove=None, rename_samples=
         line_ar=[]
         for field in datafields:
             value = line[field]
-            if rename_samples and 'SampleID' in field :
+            if rename_samples and ssparser.dfield_sid in field :
                 try:
-                    if rename_qPCR_suffix and 'SampleName' in fields_qPCR:
+                    if rename_qPCR_suffix and ssparser.dfield_snm in fields_qPCR:
                         #substitute SampleID with SampleName, add Sample_ as prefix and remove __qPCR_ suffix
-                        value =re.sub('__qPCR_$', '', 'Sample_{}'.format(line['SampleName']))
+                        value =re.sub('__qPCR_$', '', 'Sample_{}'.format(line[ssparser.dfield_snm]))
                     else:
                         #substitute SampleID with SampleName, add Sample_ as prefix
-                        value ='Sample_{}'.format(line['SampleName'])
+                        value ='Sample_{}'.format(line[ssparser.dfield_snm])
                 except:
                         #otherwise add Sample_ as prefix
-                        value = 'Sample_{}'.format(line['SampleID'])
+                        value = 'Sample_{}'.format(line[ssparser.dfield_sid])
             elif rename_qPCR_suffix and field in fields_qPCR:
                 value = re.sub('__qPCR_$', '', line[field])
                                                                                                                             

--- a/taca/illumina/HiSeq_Runs.py
+++ b/taca/illumina/HiSeq_Runs.py
@@ -171,13 +171,13 @@ class HiSeq_Run(Run):
                         return False
                     index_counter = {}
                     indexes_fastq1 = glob.glob(os.path.join(NoIndex_Undetermiend,
-                                                current_lane['Sample_Project'],
-                                                current_lane['Sample_ID'],
-                                                "{}_S?_L00{}_R2_001.fastq.gz".format(current_lane['Sample_Name'], lane_id)))[0]
+                                                current_lane[self.runParserObj.samplesheet.proj],
+                                                current_lane[self.runParserObj.samplesheet.sid],
+                                                "{}_S?_L00{}_R2_001.fastq.gz".format(current_lane[self.runParserObj.samplesheet.snm], lane_id)))[0]
                     indexes_fastq2 = glob.glob(os.path.join(NoIndex_Undetermiend,
-                                                current_lane['Sample_Project'],
-                                                current_lane['Sample_ID'],
-                                                "{}_S?_L00{}_R3_001.fastq.gz".format(current_lane['Sample_Name'], lane_id)))[0]
+                                                current_lane[self.runParserObj.samplesheet.proj],
+                                                current_lane[self.runParserObj.samplesheet.sid],
+                                                "{}_S?_L00{}_R3_001.fastq.gz".format(current_lane[self.runParserObj.samplesheet.snm], lane_id)))[0]
                     # I assume these two files are always present, maybe it is posisble to have no index with a single index...
                     logger.info("Computing Undetermiend indexes for NoIndex lane {}".format(lane_id))
                     zcat=subprocess.Popen(['zcat', indexes_fastq1], stdout=subprocess.PIPE)
@@ -647,9 +647,9 @@ class HiSeq_Run(Run):
         for line in ssparser.data:
             entry = {}
             for field, value in line.iteritems():
-                if 'SampleID' in field :
-                    entry[_data_filed_conversion(field)] ='Sample_{}'.format(value)
-                    entry['Sample_Name'] = value
+                if ssparser.dfield_sid in field :
+                    entry[ssparser.dfield_sid] ='Sample_{}'.format(value)
+                    entry[ssparser.dfield_snm] = value
                 elif "Index" in field:
                     #in this case we need to distinguish between single and dual index
                     entry[_data_filed_conversion(field)] = value.split("-")[0]
@@ -661,13 +661,14 @@ class HiSeq_Run(Run):
                     entry[_data_filed_conversion(field)] = value
             data.append(entry)
 
-        fields_to_output = ['Lane', 'Sample_ID', 'Sample_Name', 'index', 'index2', 'Sample_Project']
+        fields_to_output = ['Lane', ssparser.dfield_sid, ssparser.dfield_snm, 'index', 'index2', ssparser.dfield_proj]
         #now create the new SampleSheet data section
         output+="[Data]{}".format(os.linesep)
         for field in ssparser.datafields:
-            new_field = _data_filed_conversion(field)
-            if new_field not in fields_to_output:
-                fields_to_output.append(new_field)
+            if field not in fields_to_output:
+                new_field = _data_filed_conversion(field)
+                if new_field not in fields_to_output:
+                    fields_to_output.append(new_field)
         output+=",".join(fields_to_output)
         output+=os.linesep
         #now process each data entry and output it

--- a/taca/illumina/HiSeq_Runs.py
+++ b/taca/illumina/HiSeq_Runs.py
@@ -171,13 +171,13 @@ class HiSeq_Run(Run):
                         return False
                     index_counter = {}
                     indexes_fastq1 = glob.glob(os.path.join(NoIndex_Undetermiend,
-                                                current_lane[self.runParserObj.samplesheet.proj],
-                                                current_lane[self.runParserObj.samplesheet.sid],
-                                                "{}_S?_L00{}_R2_001.fastq.gz".format(current_lane[self.runParserObj.samplesheet.snm], lane_id)))[0]
+                                                current_lane[self.runParserObj.samplesheet.dfield_proj],
+                                                current_lane[self.runParserObj.samplesheet.dfield_sid],
+                                                "{}_S?_L00{}_R2_001.fastq.gz".format(current_lane[self.runParserObj.samplesheet.dfield_snm], lane_id)))[0]
                     indexes_fastq2 = glob.glob(os.path.join(NoIndex_Undetermiend,
-                                                current_lane[self.runParserObj.samplesheet.proj],
-                                                current_lane[self.runParserObj.samplesheet.sid],
-                                                "{}_S?_L00{}_R3_001.fastq.gz".format(current_lane[self.runParserObj.samplesheet.snm], lane_id)))[0]
+                                                current_lane[self.runParserObj.samplesheet.dfield_proj],
+                                                current_lane[self.runParserObj.samplesheet.dfield_sid],
+                                                "{}_S?_L00{}_R3_001.fastq.gz".format(current_lane[self.runParserObj.samplesheet.dfield_snm], lane_id)))[0]
                     # I assume these two files are always present, maybe it is posisble to have no index with a single index...
                     logger.info("Computing Undetermiend indexes for NoIndex lane {}".format(lane_id))
                     zcat=subprocess.Popen(['zcat', indexes_fastq1], stdout=subprocess.PIPE)

--- a/taca/illumina/MiSeq_Runs.py
+++ b/taca/illumina/MiSeq_Runs.py
@@ -78,9 +78,9 @@ class MiSeq_Run(HiSeq_Run):
         for line in ssparser.data:
             entry = {}
             for field, value in line.iteritems():
-                if 'Sample_ID' in field:
+                if ssparser.dfield_sid in field:
                     entry[field] ='Sample_{}'.format(value)
-                elif 'Sample_Project' in field:
+                elif ssparser.dfield_proj in field:
                     entry[field] = value.replace(".", "__")
                 else:
                     entry[field] = value
@@ -89,7 +89,7 @@ class MiSeq_Run(HiSeq_Run):
             data.append(entry)
 
 
-        fields_to_output = ['Lane', 'Sample_ID', 'Sample_Name', 'index', 'Sample_Project']
+        fields_to_output = ['Lane', ssparser.dfield_sid, ssparser.dfield_snm, 'index', ssparser.dfield_proj]
         #now create the new SampleSheet data section
         output+="[Data]{}".format(os.linesep)
         for field in ssparser.datafields:


### PR DESCRIPTION
There is high possibility for the samplesheet headers to change, so it would be better to stop using hard coded header names to do stuff. 