### PR TITLE
Fixed a bug in the system call to rsync inside the transfer_run function.

### DIFF
--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -234,13 +234,11 @@ def run_preprocessing(run, force_trasfer=True, statusdb=True):
     else:
         data_dirs = CONFIG.get('analysis').get('data_dirs')
         for data_dir in data_dirs:
-            runs = glob.glob(os.path.join(data_dir, '1*XX'))
+            # Run folder can end in XX or XY
+            runs = glob.glob(os.path.join(data_dir, '[1-9]*X[X|Y]'))
             # Try MiSeq runs as well
             if not runs:
-                runs = glob.glob(os.path.join(data_dir, '1*000000000*'))
-            # Try NextSeq runs as well
-            if not runs:
-                runs = glob.glob(os.path.join(data_dir, '[1-9]*'))
+                runs = glob.glob(os.path.join(data_dir, '[1-9]*000000000*'))
             for _run in runs:
                 runObj = get_runObj(_run)
                 if not runObj:

--- a/taca/illumina/Runs.py
+++ b/taca/illumina/Runs.py
@@ -244,12 +244,11 @@ class Run(object):
             :param bool analysis: Trigger analysis on remote server
         """
         # TODO: check the run type and build the correct rsync command
-        command_line = ['rsync', '-Lav']
+	# The option -a implies -o and -g which is not the desired behaviour
+        command_line = ['rsync', '-Lav', '--no-o', '--no-g']
         # Add R/W permissions to the group
         command_line.append('--chmod=g+rw')
-        # rsync works in a really funny way, if you don't understand this, refer to
-        # this note: http://silentorbit.com/notes/2013/08/rsync-by-extension/
-        # this horrible thing here avoids data dup when we use multiple indexes in a lane/FC
+        # This horrible thing here avoids data dup when we use multiple indexes in a lane/FC
         command_line.append("--exclude=Demultiplexing_*/*_*") 
         command_line.append("--include=*/")
         for to_include in self.CONFIG['analysis_server']['sync']['include']:


### PR DESCRIPTION
The option -a in rsync implies -o and -g which tell rsync to keep the user and group of the source files which is not the desired behaviour. The option -o only works if the command is invoked by a root user but the option -g works with a non sudo user. Somehow, magically Uppmax was ignoring this but it is safer and more correct to explicitly tell rsync that destination files should be own by the user invoking rsync and its group. 