### PR TITLE
taca bioinfo_deliveries: add fail_run command

### DIFF
--- a/taca/utils/cli.py
+++ b/taca/utils/cli.py
@@ -20,3 +20,11 @@ def updaterun(rundir):
 def update():
     """saves the bioinfo data of everything that can be found to statusdb"""
     bt.collect_runs()
+
+@bioinfo_deliveries.command()
+@click.argument('runid')
+@click.option('-p','--project', is_flag=False, help='Fail run for the specified project')
+def fail_run(runid, project=None):
+    """updates the status of the specified run to 'Failed'.
+    Example of RUNID: 170113_ST-E00269_0163_BHCVH7ALXX"""
+    bt.fail_run(runid, project)


### PR DESCRIPTION
example of usage: `taca bioinfo_deliveries fail_run 170113_ST-E00269_0163_BHCVH7ALXX`
or if it's only for specific project: `taca bioinfo_deliveries fail_run 170113_ST-E00269_0163_BHCVH7ALXX -p P6505`

requires status_db view `full_doc/run_id_to_doc`, which is this PR:
https://github.com/SciLifeLab/StatusDB_views/pull/59