### PR TITLE
Hopefully solved the issue with the missing emails

### DIFF
--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.6.8.0'
+__version__ = '0.6.8.1'

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -89,6 +89,9 @@ def _upload_to_statusdb(run):
     """ Triggers the upload to statusdb using the dependency flowcell_parser
         :param Run run: the object run
     """
+    return
+    import pdb
+    pdb.set_trace()
     couch = fcpdb.setupServer(CONFIG)
     db = couch[CONFIG['statusdb']['xten_db']]
     parser = run.runParserObj
@@ -217,11 +220,12 @@ def run_preprocessing(run, force_trasfer=True, statusdb=True):
 
             # Transfer to analysis server if flag is True
             if run.transfer_to_analysis_server:
+                mail_recipients = CONFIG.get('mail', {}).get('recipients')
                 logger.info('Transferring run {} to {} into {}'
                             .format(run.id,
                                     run.CONFIG['analysis_server']['host'],
                                     run.CONFIG['analysis_server']['sync']['data_archive']))
-                run.transfer_run(t_file,  False) # Do not trigger analysis
+                run.transfer_run(t_file,  False, mail_recipients) # Do not trigger analysis
 
             # Archive the run if indicated in the config file
             if 'storage' in CONFIG:

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -89,9 +89,6 @@ def _upload_to_statusdb(run):
     """ Triggers the upload to statusdb using the dependency flowcell_parser
         :param Run run: the object run
     """
-    return
-    import pdb
-    pdb.set_trace()
     couch = fcpdb.setupServer(CONFIG)
     db = couch[CONFIG['statusdb']['xten_db']]
     parser = run.runParserObj


### PR DESCRIPTION
I had previously added the email recipients to the wrong call of `transfer_run` this one is the correct one that's being called automatically by TACA after demultiplexing. 