### PR TITLE
Add option to transfer runfolder to Irma

### DIFF
--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -168,9 +168,12 @@ def transfer_runfolder(run_dir, pid):
         return
 
     # Create a tar archive of the runfolder
-    archive = os.path.basename(run_dir) + ".tar.gz"
+    dir_name = os.path.basename(run_dir)
+    archive = dir_name + ".tar.gz"
+    run_dir_path = os.path.dirname(run_dir)
+
     try:
-        subprocess.call(["tar", "--exclude", "Demultiplexing*", "--exclude", "demux_*", "--exclude", "rsync*", "--exclude", "*.csv", "-cvzf", archive, run_dir])
+        subprocess.call(["tar", "--exclude", "Demultiplexing*", "--exclude", "demux_*", "--exclude", "rsync*", "--exclude", "*.csv", "-cvzf", archive, "-C", run_dir_path, dir_name])
     except:
         logger.warn("Error creating tar archive")
         return

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -212,15 +212,15 @@ def transfer_runfolder(run_dir, pid):
     return
 
 def extract_project_samplesheet(sample_sheet, pid):
-    header_lines = ""
+    header_line = ""
     project_entries = ""
     with open(sample_sheet) as f:
         for line in f:
-            if not line[0].isdigit():  # include the header
-                header_lines += line
+            if line.split(",")[0] == 'Lane':  # include the header
+                header_line += line
             elif pid in line:
                 project_entries += line  # include only lines related to the specified project
-    new_samplesheet_content = header_lines + project_entries
+    new_samplesheet_content = header_line + project_entries
     return new_samplesheet_content
 
 def run_preprocessing(run, force_trasfer=True, statusdb=True):

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -216,7 +216,7 @@ def extract_project_samplesheet(sample_sheet, pid):
     project_entries = ""
     with open(sample_sheet) as f:
         for line in f:
-            if line.split(",")[0] == 'Lane':  # include the header
+            if line.split(",")[0] is 'Lane' or 'FCID':  # include the header
                 header_line += line
             elif pid in line:
                 project_entries += line  # include only lines related to the specified project

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -147,6 +147,15 @@ def transfer_run(run_dir, analysis):
         runObj.transfer_run(os.path.join("nosync",CONFIG['analysis']['status_dir'], 'transfer.tsv'),
                             analysis, mail_recipients) # do not start analsysis automatically if I force the transfer
 
+
+def transfer_runfolder(run_dir, pid):
+    """ Transfer the entire run folder for a specified project
+    :param: string run_dir: the run to transfer
+    :param: string pid: the project to include in the SampleSheet
+    """
+    print "Transferring run folder for project " + pid
+    return
+
 def run_preprocessing(run, force_trasfer=True, statusdb=True):
     """ Run demultiplexing in all data directories
         :param str run: Process a particular run instead of looking for runs

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -13,7 +13,6 @@ from taca.illumina.MiSeq_Runs import MiSeq_Run
 from taca.illumina.NextSeq_Runs import NextSeq_Run
 from taca.illumina.NovaSeq_Runs import NovaSeq_Run
 from taca.utils.config import CONFIG
-from taca.utils.misc import call_external_command_detached
 from taca.utils.transfer import RsyncAgent
 
 import flowcell_parser.db as fcpdb
@@ -152,7 +151,7 @@ def transfer_run(run_dir, analysis):
 
 
 def transfer_runfolder(run_dir, pid):
-    """ Transfer the entire run folder for a specified project and run
+    """ Transfer the entire run folder for a specified project and run to uppmax
     :param: string run_dir: the run to transfer
     :param: string pid: the project to include in the SampleSheet
     """
@@ -217,10 +216,10 @@ def extract_project_samplesheet(sample_sheet, pid):
     project_entries = ""
     with open(sample_sheet) as f:
         for line in f:
-            if not line[0].isdigit():
+            if not line[0].isdigit():  # include the header
                 header_lines += line
             elif pid in line:
-                project_entries += line
+                project_entries += line  # include only lines related to the specified project
     new_samplesheet_content = header_lines + project_entries
     return new_samplesheet_content
 

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -213,12 +213,16 @@ def transfer_runfolder(run_dir, pid):
     return
 
 def extract_project_samplesheet(sample_sheet, pid):
+    header_lines = ""
     project_entries = ""
     with open(sample_sheet) as f:
         for line in f:
-            if pid in line:
+            if not line[0].isdigit():
+                header_lines += line
+            elif pid in line:
                 project_entries += line
-    return project_entries
+    new_samplesheet_content = header_lines + project_entries
+    return new_samplesheet_content
 
 def run_preprocessing(run, force_trasfer=True, statusdb=True):
     """ Run demultiplexing in all data directories

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -216,7 +216,7 @@ def extract_project_samplesheet(sample_sheet, pid):
     project_entries = ""
     with open(sample_sheet) as f:
         for line in f:
-            if line.split(",")[0] is 'Lane' or 'FCID':  # include the header
+            if line.split(",")[0] in ('Lane', 'FCID'):  # include the header
                 header_line += line
             elif pid in line:
                 project_entries += line  # include only lines related to the specified project

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -186,13 +186,11 @@ def transfer_runfolder(run_dir, pid):
         return
 
     # Rsync the files to irma
-    destination = "test"
-    #destination = "/proj/ngi2016003/incoming"
+    destination = CONFIG["analysis"]["deliver_runfolder"].get("destination")
     rsync_opts = {"--no-o" : None, "--no-g" : None, "--chmod" : "g+rw"}
-    archive_transfer = RsyncAgent(archive, dest_path=destination, remote_host="b5.biotech.kth.se", remote_user="sara.sjunnebo", validate=False, opts=rsync_opts)
-    md5_transfer = RsyncAgent(md5file, dest_path=destination, remote_host="b5.biotech.kth.se", remote_user="sara.sjunnebo", validate=False, opts=rsync_opts)
-    #archive_transfer = RsyncAgent(archive, dest_path=destination, remote_host="irma1.uppmax.uu.se", remote_user="funk_903", validate=False, opts=rsync_opts)
-    #md5_transfer = RsyncAgent(md5file, dest_path=destination, remote_host="irma1.uppmax.uu.se", remote_user="funk_903", validate=False, opts=rsync_opts)
+    connection_details = CONFIG["analysis"]["deliver_runfolder"].get("analysis_server")
+    archive_transfer = RsyncAgent(archive, dest_path=destination, remote_host=connection_details["host"], remote_user=connection_details["user"], validate=False, opts=rsync_opts)
+    md5_transfer = RsyncAgent(md5file, dest_path=destination, remote_host=connection_details["host"], remote_user=connection_details["user"], validate=False, opts=rsync_opts)
 
     try:
         archive_transfer.transfer()

--- a/taca/analysis/cli.py
+++ b/taca/analysis/cli.py
@@ -28,9 +28,9 @@ def demultiplex(run, force):
 def transfer(rundir, analysis, runfolder_project):
     """Transfers the run without qc"""
     if not runfolder_project:
-            an.transfer_run(rundir, analysis=analysis)
+        an.transfer_run(rundir, analysis=analysis)
     else:
-            an.transfer_runfolder(rundir, pid=runfolder_project)
+        an.transfer_runfolder(rundir, pid=runfolder_project)
 
 @analysis.command()
 @click.argument('rundir')

--- a/taca/analysis/cli.py
+++ b/taca/analysis/cli.py
@@ -22,12 +22,15 @@ def demultiplex(run, force):
 
 @analysis.command()
 @click.option('-a','--analysis', is_flag=False, help='Trigger the analysis for the transferred flowcell')
+@click.option('--runfolder', is_flag=False, help='Project ID for runfolder transfer')
 @click.argument('rundir')
 
-def transfer(rundir, analysis):
+def transfer(rundir, analysis, runfolder):
     """Transfers the run without qc"""
-    an.transfer_run(rundir, analysis=analysis)
-
+    if not runfolder:
+            an.transfer_run(rundir, analysis=analysis)
+    else:
+            an.transfer_runfolder(rundir, pid=runfolder)
 @analysis.command()
 @click.argument('rundir')
 def updatedb(rundir):

--- a/taca/analysis/cli.py
+++ b/taca/analysis/cli.py
@@ -22,15 +22,16 @@ def demultiplex(run, force):
 
 @analysis.command()
 @click.option('-a','--analysis', is_flag=False, help='Trigger the analysis for the transferred flowcell')
-@click.option('--runfolder', is_flag=False, help='Project ID for runfolder transfer')
+@click.option('--runfolder-project', is_flag=False, help='Project ID for runfolder transfer')
 @click.argument('rundir')
 
-def transfer(rundir, analysis, runfolder):
+def transfer(rundir, analysis, runfolder_project):
     """Transfers the run without qc"""
-    if not runfolder:
+    if not runfolder_project:
             an.transfer_run(rundir, analysis=analysis)
     else:
-            an.transfer_runfolder(rundir, pid=runfolder)
+            an.transfer_runfolder(rundir, pid=runfolder_project)
+
 @analysis.command()
 @click.argument('rundir')
 def updatedb(rundir):


### PR DESCRIPTION
* Adds the option  `--runfolder-project <PID> /path/to/run/dir` to `taca analysis transfer`.
* The option will:
** Copy the header and lines containing the PID from SampleSheet.csv in the run folder to SampleSheet.txt
** Generate a tarball of the run folder, excluding log files and csv files.
** Generate an md5 file for the tarball
** rsync the tarball and md5file to the location specified in taca.yaml (eg incoming on irma)
** clean up the generated files (tarball, md5file and SampleSheet.txt) 
* Requires an addition of connection details to taca.yaml to work.