### PR TITLE
Fix issue with click 7.1

### DIFF
--- a/taca/cli.py
+++ b/taca/cli.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
-
 from pkg_resources import iter_entry_points
-
 import click
 import taca.log
 
@@ -12,27 +10,25 @@ from taca.utils import config as conf
 
 logger = logging.getLogger(__name__)
 
-
 @click.group()
 @click.version_option(__version__)
 # Priority for the configuration file is: environment variable > -c option > default
 @click.option('-c', '--config-file',
-			  default=os.path.join(os.environ['HOME'], '.taca/taca.yaml'),
-			  envvar='TACA_CONFIG',
-			  type=click.File('r'),
-			  help='Path to TACA configuration file')
+              default=os.path.join(os.environ['HOME'], '.taca/taca.yaml'),
+              envvar='TACA_CONFIG',
+              type=click.File('r'),
+              help='Path to TACA configuration file')
+
 @click.pass_context
 def cli(ctx, config_file):
-	""" Tool for the Automation of Storage and Analyses """
-	ctx.obj = {}
-	config = conf.load_yaml_config(config_file)
-	log_file = config.get('log', {}).get('file', None)
-	if log_file:
-		level = config.get('log').get('log_level', 'INFO')
-		taca.log.init_logger_file(log_file, level)
-
-	logger.debug('starting up CLI')
-
+    """ Tool for the Automation of Storage and Analyses """
+    ctx.obj = {}
+    config = conf.load_yaml_config(config_file.name)
+    log_file = config.get('log', {}).get('file', None)
+    if log_file:
+        level = config.get('log').get('log_level', 'INFO')
+        taca.log.init_logger_file(log_file, level)
+    logger.debug('starting up CLI')
 
 #Add subcommands dynamically to the CLI
 for entry_point in iter_entry_points('taca.subcommands'):


### PR DESCRIPTION
The latest click version makes TACA throw a TypeError when loading a config file:

`TypeError: coercing to Unicode: need string or buffer, _NonClosingTextIOWrapper found`

Passing config_file.name instead of the object solves the issue.