### PR TITLE
Make sure the runfolder is group writeable when transferred to irma

### DIFF
--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -189,7 +189,7 @@ def transfer_runfolder(run_dir, pid):
 
     # Rsync the files to irma
     destination = CONFIG["analysis"]["deliver_runfolder"].get("destination")
-    rsync_opts = {"--no-o" : None, "--no-g" : None, "--chmod" : "g+rw"}
+    rsync_opts = {"-Lav": None, "--no-o" : None, "--no-g" : None, "--chmod" : "g+rw"}
     connection_details = CONFIG["analysis"]["deliver_runfolder"].get("analysis_server")
     archive_transfer = RsyncAgent(archive, dest_path=destination, remote_host=connection_details["host"], remote_user=connection_details["user"], validate=False, opts=rsync_opts)
     md5_transfer = RsyncAgent(md5file, dest_path=destination, remote_host=connection_details["host"], remote_user=connection_details["user"], validate=False, opts=rsync_opts)


### PR DESCRIPTION
Added `-Lav` options to the runfolder rsync command to Irma. In combination with previous options, this will make sure that the runfolder is group writeable so that we can delete it from incoming without contacting Uppmax support.