### PR TITLE
Remove statusdb dependancy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 click
 requests
 pyyaml
-statusdb
 flowcell_parser
 soupsieve<2.0
 beautifulsoup4

--- a/taca/cleanup/cleanup.py
+++ b/taca/cleanup/cleanup.py
@@ -10,9 +10,8 @@ from collections import defaultdict
 from datetime import datetime
 from glob import glob
 
-from statusdb.db import connections as statusdb
 from taca.utils.config import CONFIG
-from taca.utils import filesystem, misc
+from taca.utils import filesystem, misc, statusdb
 from taca.illumina.MiSeq_Runs import MiSeq_Run
 
 logger = logging.getLogger(__name__)
@@ -132,14 +131,18 @@ def cleanup_irma(days_fastq, days_analysis, only_fastq, only_analysis, clean_und
         if date:
             date = datetime.strptime(date, '%Y-%m-%d')
     except KeyError as e:
-        logger.error('Config file is missing the key {}, make sure it have all required information'.format(str(e)))
+        logger.error('Config file is missing the key {}, make sure it has all required information'.format(str(e)))
         raise SystemExit
     except ValueError as e:
         logger.error('Date given with "--date" option is not in required format, see help for more info')
         raise SystemExit
 
-    # make a connection for project db #
-    pcon = statusdb.ProjectSummaryConnection(conf=status_db_config)
+    # make a connection for project db
+    config_statusdb = CONFIG.get('statusdb', None)
+    if not config_statusdb:
+            raise AttributeError('Config file is missing the key statusdb,'
+                                 'make sure it has all required information')
+    pcon = statusdb.ProjectSummaryConnection(config_statusdb)
     assert pcon, 'Could not connect to project database in StatusDB'
 
     # make exclude project list if provided

--- a/taca/cleanup/cleanup.py
+++ b/taca/cleanup/cleanup.py
@@ -179,7 +179,7 @@ def cleanup_irma(days_fastq, days_analysis,
                 fc_abs_path = os.path.join(flowcell_dir, fc)
                 with filesystem.chdir(fc_abs_path):
                     if not os.path.exists(flowcell_project_source):
-                        logger.warn('Flowcell {} do not contain a "{}" directory'.format(fc, flowcell_project_source))
+                        logger.warn('Flowcell {} does not contain a "{}" directory'.format(fc, flowcell_project_source))
                         continue
                     projects_in_fc = [d for d in os.listdir(flowcell_project_source) \
                                       if re.match(r'^[A-Z]+[_\.]+[A-Za-z]+_\d\d_\d\d$',d) and \

--- a/taca/cleanup/cleanup.py
+++ b/taca/cleanup/cleanup.py
@@ -90,7 +90,10 @@ def cleanup_processing(seconds):
         logger.error(msg)
         misc.send_mail(sbj, msg, cnt)
 
-def cleanup_irma(days_fastq, days_analysis, only_fastq, only_analysis, clean_undetermined, status_db_config, exclude_projects, list_only, date, dry_run=False):
+def cleanup_irma(days_fastq, days_analysis,
+                 only_fastq, only_analysis,
+                 clean_undetermined, exclude_projects,
+                 list_only, date, dry_run=False):
     """Remove fastq/analysis data for projects that have been closed more than given
     days (as days_fastq/days_analysis) from the given 'irma' cluster.
 
@@ -100,7 +103,7 @@ def cleanup_irma(days_fastq, days_analysis, only_fastq, only_analysis, clean_und
     :param bool only_analysis: Remove only analysis data for closed projects
     :param bool dry_run: Will summarize what is going to be done without really doing it
 
-    Example format for config file
+    Example format for entry in the taca config file
     cleanup:
         irma:
             flowcell:
@@ -176,7 +179,7 @@ def cleanup_irma(days_fastq, days_analysis, only_fastq, only_analysis, clean_und
                 fc_abs_path = os.path.join(flowcell_dir, fc)
                 with filesystem.chdir(fc_abs_path):
                     if not os.path.exists(flowcell_project_source):
-                        logger.warn('Flowcell {} do not contain a "{}" direcotry'.format(fc, flowcell_project_source))
+                        logger.warn('Flowcell {} do not contain a "{}" directory'.format(fc, flowcell_project_source))
                         continue
                     projects_in_fc = [d for d in os.listdir(flowcell_project_source) \
                                       if re.match(r'^[A-Z]+[_\.]+[A-Za-z]+_\d\d_\d\d$',d) and \
@@ -348,7 +351,7 @@ def get_closed_proj_info(prj, pdoc, tdate=None):
     if not tdate:
         tdate = datetime.today()
     if not pdoc:
-        logger.warn('Seems like project {} dont have a proper statudb document, skipping it'.format(prj))
+        logger.warn('Seems like project {} does not have a proper statusdb document, skipping it'.format(prj))
     elif 'close_date' in pdoc:
         closed_date = pdoc['close_date']
         try:
@@ -386,8 +389,8 @@ def collect_analysis_data_irma(pid, analysis_root, files_ext_to_remove={}):
     return (file_list, size)
 
 def collect_fastq_data_irma(fc_root, fc_proj_src, proj_root=None, pid=None):
-    """Collect the fastq files that have to be removed from IRMA
-    return a tuple with files and total size of collected files."""
+    """Collect the fastq files that have to be removed from IRMA.
+    Return a tuple with files and total size of collected files."""
     size = 0
     file_list = {'flowcells': defaultdict(dict)}
     fc_proj_path = os.path.join(fc_root, fc_proj_src)
@@ -407,7 +410,7 @@ def collect_fastq_data_irma(fc_root, fc_proj_src, proj_root=None, pid=None):
     return (file_list, size)
 
 def collect_files_by_ext(path, ext=[]):
-    """Collect files with given extension from given path."""
+    """Collect files with a given extension from a given path."""
     if isinstance(ext, str):
         ext = [ext]
     collected_files = []

--- a/taca/cleanup/cleanup.py
+++ b/taca/cleanup/cleanup.py
@@ -5,12 +5,13 @@ import os
 import re
 import shutil
 import time
+import yaml
 
 from collections import defaultdict
 from datetime import datetime
 from glob import glob
 
-from taca.utils.config import CONFIG
+from taca.utils.config import CONFIG, load_config
 from taca.utils import filesystem, misc, statusdb
 from taca.illumina.MiSeq_Runs import MiSeq_Run
 
@@ -92,8 +93,9 @@ def cleanup_processing(seconds):
 
 def cleanup_irma(days_fastq, days_analysis,
                  only_fastq, only_analysis,
-                 clean_undetermined, exclude_projects,
-                 list_only, date, dry_run=False):
+                 clean_undetermined, status_db_config,
+                 exclude_projects, list_only,
+                 date, dry_run=False):
     """Remove fastq/analysis data for projects that have been closed more than given
     days (as days_fastq/days_analysis) from the given 'irma' cluster.
 
@@ -141,11 +143,8 @@ def cleanup_irma(days_fastq, days_analysis,
         raise SystemExit
 
     # make a connection for project db
-    config_statusdb = CONFIG.get('statusdb', None)
-    if not config_statusdb:
-            raise AttributeError('Config file is missing the key statusdb,'
-                                 'make sure it has all required information')
-    pcon = statusdb.ProjectSummaryConnection(config_statusdb)
+    db_config = load_config(status_db_config)
+    pcon = statusdb.ProjectSummaryConnection(db_config.get('statusdb'))
     assert pcon, 'Could not connect to project database in StatusDB'
 
     # make exclude project list if provided

--- a/taca/cleanup/cli.py
+++ b/taca/cleanup/cli.py
@@ -5,7 +5,11 @@ from taca.utils import misc
 
 @click.group()
 @click.pass_context
-def cleanup(ctx):
+@click.option('--status_db_config',
+              type=click.Path(exists=True, dir_okay=False),
+              envvar='STATUS_DB_CONFIG',
+              help='Path to statusdb-configuration.')
+def cleanup(ctx, status_db_config):
 	"""Cleaning up servers - management methods and utilities."""
 	pass
 
@@ -60,6 +64,7 @@ def preproc(ctx, days, hours):
 @click.pass_context
 def irma(ctx, days_fastq, days_analysis, only_fastq, only_analysis, clean_undetermined, date, exclude_projects, list_only, dry_run):
     """Do appropriate cleanup on IRMA."""
+    status_db_config = ctx.parent.params['status_db_config']
     if only_fastq and only_analysis:
         raise SystemExit('ERROR: Both option "only_fastq" and "only_analysis" is given, should only give either one')
     if not days_fastq and not only_analysis and not clean_undetermined:
@@ -68,5 +73,6 @@ def irma(ctx, days_fastq, days_analysis, only_fastq, only_analysis, clean_undete
         raise SystemExit('ERROR: "days_analysis" is not given while not selecting "only_fastq" option')
     cln.cleanup_irma(days_fastq, days_analysis,
                      only_fastq, only_analysis,
-                     clean_undetermined, exclude_projects,
-                     list_only, date, dry_run)
+                     clean_undetermined, status_db_config,
+                     exclude_projects, list_only,
+                     date, dry_run)

--- a/taca/cleanup/cli.py
+++ b/taca/cleanup/cli.py
@@ -1,66 +1,72 @@
-""" CLI for the storage subcommand
-"""
+"""CLI for the storage subcommand."""
 import click
 from taca.cleanup import cleanup as cln
 from taca.utils import misc
 
 @click.group()
 @click.pass_context
-@click.option('--status_db_config', type=click.Path(exists=True, dir_okay=False),
-              help="Config to use for fetching 'status_db' credentials")
-def cleanup(ctx, status_db_config):
-	""" Cleaning up servers - management methods and utilities """
+def cleanup(ctx):
+	"""Cleaning up servers - management methods and utilities."""
 	pass
 
 # cleanup subcommands
 @cleanup.command()
 @click.option('-d', '--days', type=click.IntRange(min=1),
-              help="Days to consider as thershold, should not be combined with option '--hours'")
+              help='Days to consider as thershold, should not be combined with option "--hours"')
 @click.option('-h', '--hours', type=click.IntRange(min=1),
-              help="Hours to consider as thershold, should not be combined with option '--days'")
+              help='Hours to consider as thershold, should not be combined with option "--days"')
 @click.pass_context
 def nas(ctx, days, hours):
-    """ Do appropriate cleanup on NAS"""
+    """Do appropriate cleanup on NAS."""
     seconds = misc.to_seconds(days, hours)
     cln.cleanup_nas(seconds)
 
 @cleanup.command()
 @click.option('-d', '--days', type=click.IntRange(min=1),
-              help="Days to consider as thershold, should not be combined with option '--hours'")
+              help='Days to consider as thershold, should not be combined with option "--hours"')
 @click.option('-h', '--hours', type=click.IntRange(min=1),
-              help="Hours to consider as thershold, should not be combined with option '--days'")
+              help='Hours to consider as thershold, should not be combined with option "--days"')
 @click.pass_context
 def preproc(ctx, days, hours):
-    """ Do appropriate cleanup on PREPROC"""
+    """Do appropriate cleanup on preproc."""
     seconds = misc.to_seconds(days, hours)
     cln.cleanup_processing(seconds)
 
 @cleanup.command()
 @click.option('--days_fastq', type=click.IntRange(min=1),
-              help="Days to consider as thershold for removing 'fastq' files")
+              help='Days to consider as thershold for removing "fastq" files')
 @click.option('--days_analysis', type=click.IntRange(min=1),
-              help="Days to consider as thershold for removing analysis data")
-@click.option('--only_fastq', is_flag=True, help="Clean only fastq data in 'irma'")
-@click.option('--only_analysis', is_flag=True, help="Clean only analysis data in 'irma'")
-@click.option('--date', type=click.STRING, help="Consider the given date instead of today while collecting closed projects. \
-              Date format should be 'YYYY-MM-DD', ex: '2016-01-31'")
+              help='Days to consider as thershold for removing analysis data')
+@click.option('--only_fastq', is_flag=True,
+              help='Clean only fastq data in "irma"')
+@click.option('--only_analysis', is_flag=True,
+              help='Clean only analysis data in "irma"')
+@click.option('--date', type=click.STRING,
+              help='Consider the given date instead of today while collecting closed projects. '
+              'Date format should be "YYYY-MM-DD", ex: "2016-01-31"')
 @click.option('--exclude_projects', type=click.STRING,
-              help="A project or a file with list of project to exclude from deleting, Both name or id \
-              can be given. Examples: --exclude_projects P1234 or --exclude_projects P1234,P5678 or \
-              --exclude_projects file_with_projects_id.txt")
-@click.option('--clean_undetermined', is_flag=True, help="Remove only the undetermined reads for a \
-              flowcell that have all project cleaned. All other parameters are ignored if this flag is called.")
-@click.option('-l', '--list_only', is_flag=True, help="Only build the project list that will be cleaned")
-@click.option('-n', '--dry_run', is_flag=True, help='Perform dry run i.e. Executes nothing but log')
+              help='A project or a file with a list of projects to exclude from deleting. '
+              'Either name or id can be given. Examples: --exclude_projects P1234 or '
+              '--exclude_projects P1234,P5678 or '
+              '--exclude_projects file_with_projects_id.txt')
+@click.option('--clean_undetermined', is_flag=True,
+              help='Remove only the undetermined reads for a flowcell that have '
+              'all project cleaned. All other parameters are ignored if this '
+              'flag is called.')
+@click.option('-l', '--list_only', is_flag=True,
+              help='Only build the project list that will be cleaned')
+@click.option('-n', '--dry_run', is_flag=True,
+              help='Perform dry run i.e. execute nothing but log')
 @click.pass_context
 def irma(ctx, days_fastq, days_analysis, only_fastq, only_analysis, clean_undetermined, date, exclude_projects, list_only, dry_run):
-    """ Do appropriate cleanup on IRMA"""
-    status_db_config = ctx.parent.params['status_db_config']
+    """Do appropriate cleanup on IRMA."""
     if only_fastq and only_analysis:
-        raise SystemExit("ERROR: Both option 'only_fastq' and 'only_analysis' is given, should only give either one")
+        raise SystemExit('ERROR: Both option "only_fastq" and "only_analysis" is given, should only give either one')
     if not days_fastq and not only_analysis and not clean_undetermined:
-        raise SystemExit("ERROR: 'days_fastq' is not given while not selecting 'only_analysis' option")
+        raise SystemExit('ERROR: "days_fastq" is not given while not selecting "only_analysis" option')
     if not days_analysis and not only_fastq and not clean_undetermined:
-        raise SystemExit("ERROR: 'days_analysis' is not given while not selecting 'only_fastq' option")
-    cln.cleanup_irma(days_fastq, days_analysis, only_fastq, only_analysis, clean_undetermined, status_db_config,
-                    exclude_projects, list_only, date, dry_run)
+        raise SystemExit('ERROR: "days_analysis" is not given while not selecting "only_fastq" option')
+    cln.cleanup_irma(days_fastq, days_analysis,
+                     only_fastq, only_analysis,
+                     clean_undetermined, exclude_projects,
+                     list_only, date, dry_run)

--- a/taca/utils/statusdb.py
+++ b/taca/utils/statusdb.py
@@ -28,8 +28,6 @@ class StatusdbSession(object):
         else:
             view = self.name_view
         if not view.get(name, None):
-            if self.log:
-                self.log.warn('no entry "{}" in {}'.format(name, self.db))
             return None
         return self.db.get(view.get(name))
 

--- a/taca/utils/statusdb.py
+++ b/taca/utils/statusdb.py
@@ -1,0 +1,42 @@
+"""Classes for handling connection to StatusDB."""
+
+import couchdb
+
+
+class statusdb_session(object):
+    """Wrapper class for couchdb."""
+    def __init__(self, config, db=None):
+        user = config.get('username')
+        password = config.get('password')
+        port = config.get('port')
+        url = config.get('url')
+        url_string = 'http://{}:{}@{}:{}'.format(user, password, url, port)
+        display_url_string = 'http://{}:{}@{}:{}'.format(user, '*********', url, port)
+        self.connection = couchdb.Server(url=url_string)
+        if not self.connection:
+            raise Exception('Couchdb connection failed for url {}'.format(display_url_string))
+        if db:
+            self.db_connection = self.connection[db]
+
+    def get_entry(self, name, use_id_view=False):
+        """Retrieve entry from a given db for a given name.
+
+        :param name: unique name identifier (primary key, not the uuid)
+        """
+        if use_id_view:
+            view = self.id_view
+        else:
+            view = self.name_view
+        if not view.get(name, None):
+            if self.log:
+                self.log.warn('no entry "{}" in {}'.format(name, self.db))
+            return None
+        return self.db.get(view.get(name))
+
+
+class ProjectSummaryConnection(statusdb_session):
+    def __init__(self, config, dbname='projects'):
+        super(ProjectSummaryConnection, self).__init__(config)
+        self.db = self.connection[dbname]
+        self.name_view = {k.key: k.id for k in self.db.view('project/project_name', reduce=False)}
+        self.id_view = {k.key: k.id for k in self.db.view('project/project_id', reduce=False)}

--- a/taca/utils/statusdb.py
+++ b/taca/utils/statusdb.py
@@ -3,7 +3,7 @@
 import couchdb
 
 
-class statusdb_session(object):
+class StatusdbSession(object):
     """Wrapper class for couchdb."""
     def __init__(self, config, db=None):
         user = config.get('username')
@@ -34,7 +34,7 @@ class statusdb_session(object):
         return self.db.get(view.get(name))
 
 
-class ProjectSummaryConnection(statusdb_session):
+class ProjectSummaryConnection(StatusdbSession):
     def __init__(self, config, dbname='projects'):
         super(ProjectSummaryConnection, self).__init__(config)
         self.db = self.connection[dbname]

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -55,12 +55,13 @@ class TestCleanup(unittest.TestCase):
         only_fastq = False
         only_analysis = False
         clean_undetermined = False
+        status_db_config = 'data/taca_test_cfg_cleanup.yaml'
         exclude_projects = False
         list_only = False
         date = '2016-01-31'
         calls = [mock.call('data/irma/incoming/190201_A00621_0032_BHHFCFDSXX/Demultiplexing/N.Owens_19_01'),
                  mock.call('../../nobackup/NGI/ANALYSIS/P1234')]
-        cleanup.cleanup_irma(days_fastq, days_analysis, only_fastq, only_analysis, clean_undetermined, exclude_projects, list_only, date, dry_run=False)
+        cleanup.cleanup_irma(days_fastq, days_analysis, only_fastq, only_analysis, clean_undetermined, status_db_config, exclude_projects, list_only, date, dry_run=False)
         mock_touch.assert_has_calls(calls)
 
     def test_get_closed_proj_info(self):

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -55,13 +55,12 @@ class TestCleanup(unittest.TestCase):
         only_fastq = False
         only_analysis = False
         clean_undetermined = False
-        status_db_config = 'config'
         exclude_projects = False
         list_only = False
         date = '2016-01-31'
         calls = [mock.call('data/irma/incoming/190201_A00621_0032_BHHFCFDSXX/Demultiplexing/N.Owens_19_01'),
                  mock.call('../../nobackup/NGI/ANALYSIS/P1234')]
-        cleanup.cleanup_irma(days_fastq, days_analysis, only_fastq, only_analysis, clean_undetermined, status_db_config, exclude_projects, list_only, date, dry_run=False)
+        cleanup.cleanup_irma(days_fastq, days_analysis, only_fastq, only_analysis, clean_undetermined, exclude_projects, list_only, date, dry_run=False)
         mock_touch.assert_has_calls(calls)
 
     def test_get_closed_proj_info(self):


### PR DESCRIPTION
Added a new module based on the one in taca-ngi-pipeline, in order to remove the statusdb dependency which is only used in one place. I will expand this so that all connections to statusdb in TACA will eventually go through this module.