### PR TITLE
Bugfix for locating anglerfish sample sheet

### DIFF
--- a/taca/analysis/analysis_nanopore.py
+++ b/taca/analysis/analysis_nanopore.py
@@ -46,6 +46,7 @@ def process_run(run_dir, nanoseq_sample_sheet, anglerfish_sample_sheet):
     summary_file = os.path.join(run_dir, 'final_summary.txt')
     nanoseq_dir = os.path.join(run_dir, 'nanoseq_output')
     anglerfish_dir = os.path.join(run_dir, 'anglerfish_output')
+    anglerfish_sample_sheet = os.path.join(run_dir, 'anglerfish_sample_sheet.csv')
     nanoseq_exit_status_file = os.path.join(run_dir, '.exitcode_for_nanoseq')
     anglerfish_exit_status_file = os.path.join(run_dir, '.exitcode_for_anglerfish')
     email_recipients = CONFIG.get('mail').get('recipients')
@@ -53,7 +54,7 @@ def process_run(run_dir, nanoseq_sample_sheet, anglerfish_sample_sheet):
     if os.path.isfile(summary_file) and not os.path.isdir(nanoseq_dir):
         logger.info('Sequencing done for run {}. Attempting to start analysis.'.format(run_dir))
         if not nanoseq_sample_sheet:
-            nanoseq_sample_sheet, anglerfish_sample_sheet = parse_lims_sample_sheet(run_dir)
+            nanoseq_sample_sheet = parse_lims_sample_sheet(run_dir)
 
         if os.path.isfile(nanoseq_sample_sheet):
             start_nanoseq(run_dir, nanoseq_sample_sheet)
@@ -162,11 +163,11 @@ def parse_lims_sample_sheet(run_dir):
     run_id = os.path.basename(run_dir)
     lims_samplesheet = get_original_samplesheet(run_id)
     if lims_samplesheet:
-        nanoseq_samplesheet_location, anglerfish_samplesheet_location = parse_samplesheet(run_dir, lims_samplesheet)
+        nanoseq_samplesheet_location = parse_samplesheet(run_dir, lims_samplesheet)
     else:
         nanoseq_samplesheet_location = ''
         anglerfish_samplesheet_location = ''
-    return nanoseq_samplesheet_location, anglerfish_samplesheet_location
+    return nanoseq_samplesheet_location
 
 def get_original_samplesheet(run_id):
     """Find original lims sample sheet."""
@@ -216,7 +217,7 @@ def parse_samplesheet(run_dir, lims_samplesheet):
     if anglerfish_content:
         with open(anglerfish_samplesheet, 'w') as f:
             f.write(anglerfish_content)
-    return nanoseq_samplesheet, anglerfish_samplesheet
+    return nanoseq_samplesheet
 
 def start_nanoseq(run_dir, sample_sheet):
     """Start Nanoseq analysis."""

--- a/tests/test_analysis_nanopore.py
+++ b/tests/test_analysis_nanopore.py
@@ -45,7 +45,8 @@ class TestNanoporeAnalysis(unittest.TestCase):
         """Make nanoseq sample sheet from lims sample sheet."""
         run_dir = 'data/nanopore_data/run4/done_demuxing/20200104_1412_MN19414_AAU644_68125dc2'
         lims_samplesheet = 'data/nanopore_samplesheets/2020/SQK-LSK109_AAU644_Samplesheet_24-594126.csv'
-        nanoseq_samplesheet, anglerfish_sample_sheet = parse_samplesheet(run_dir, lims_samplesheet)
+        anglerfish_sample_sheet = 'data/nanopore_data/run4/done_demuxing/20200104_1412_MN19414_AAU644_68125dc2/anglerfish_sample_sheet.csv'
+        nanoseq_samplesheet = parse_samplesheet(run_dir, lims_samplesheet)
         self.assertTrue(filecmp.cmp(nanoseq_samplesheet, 'data/nanopore_samplesheets/expected/SQK-LSK109_sample_sheet.csv'))
         self.assertTrue(filecmp.cmp(anglerfish_sample_sheet, 'data/nanopore_samplesheets/expected/anglerfish_sample_sheet.csv'))
 
@@ -193,7 +194,7 @@ class TestNanoporeAnalysis(unittest.TestCase):
         """Start nanoseq analysis."""
         nanoseq_sample_sheet = 'data/nanopore_data/run2/done_sequencing/20200102_1412_MN19414_AAU642_68125dc2/SQK-LSK109_sample_sheet.csv'
         anglerfish_sample_sheet = 'some/path'
-        mock_parse_ss.return_value = (nanoseq_sample_sheet, anglerfish_sample_sheet)
+        mock_parse_ss.return_value = nanoseq_sample_sheet
         mock_isfile.return_value = True
         run_dir = 'data/nanopore_data/run2/done_sequencing/20200102_1412_MN19414_AAU642_68125dc2'
         process_run(run_dir, None, None)


### PR DESCRIPTION
Initialise anglerfish sample sheet separately so it's picked up when starting anglerfish, which is done on a the second time TACA is run on the run directory, i.e. when nanoseq is finished.