### PR TITLE
Add functionality for monitoring PromethION status

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # TACA Version Log
 
+##20230207.1
+Add functionality for monitoring PromethION status
+
 ##20230117.2
 More robust handling of ONT transfers
 

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.9.14'
+__version__ = '0.9.15'

--- a/taca/server_status/cli.py
+++ b/taca/server_status/cli.py
@@ -27,3 +27,11 @@ def cronjobs():
     """ Monitors cronjobs and updates statusdb
     """
     cj.update_cronjob_db()
+
+@server_status.command()
+def monitor_promethion():
+    """ Checks the status of PromethION and if ngi-nas is mounted
+    """
+    if not CONFIG.get('server_status', ''):
+        logging.warning("Configuration missing required entries: server_status")
+    status.check_promethion_status()

--- a/taca/server_status/cli.py
+++ b/taca/server_status/cli.py
@@ -32,6 +32,10 @@ def cronjobs():
 def monitor_promethion():
     """ Checks the status of PromethION and if ngi-nas is mounted
     """
-    if not CONFIG.get('server_status', ''):
+    if not CONFIG.get('promethion_status', ''):
         logging.warning("Configuration missing required entries: server_status")
-    status.check_promethion_status()
+    promethion_status = status.check_promethion_status()
+    if promethion_status:
+        logging.info("No issues encountered with the PromethION")
+    else:
+        logging.warning("An issue with the PromethION was encountered. Operator has been notified by email.")

--- a/taca/server_status/server_status.py
+++ b/taca/server_status/server_status.py
@@ -107,3 +107,6 @@ def update_status_db(data, server_type=None):
             raise
         else:
             logging.info('{}: Server status has been updated'.format(key))
+
+def check_promethion_status():
+    pass


### PR DESCRIPTION
To be run on preproc1. Catches both if the mount is down and if the promethion is unreachable. 

The following needs to be added to the config file:

```
promethion_status:
    server: <server url>
    path: <path to ngi_data mount on preproc>
    user: <promethion user name>
    command: ls
```