### PR TITLE
Promethion rsync fix

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,6 +1,6 @@
 # TACA Version Log
 
-## 20230418.1
+## 20230419.1
 Use a hidden file to indicate when the final rsync of ONT data to ngi-nas is done
 
 ## 20230331.1

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # TACA Version Log
 
+## 20230418.1
+Use a hidden file to indicate when the final rsync of ONT data to ngi-nas is done
+
 ## 20230331.1
 Move MinKNOW reports to ngi-internal instead of embedding in StatusDB doc
 

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.9.17'
+__version__ = '0.9.18'

--- a/taca/analysis/analysis_nanopore.py
+++ b/taca/analysis/analysis_nanopore.py
@@ -299,7 +299,7 @@ def transfer_ont_run(ont_run):
         email_message = (f"An error occured when updating statusdb with run {ont_run.run_id}.\n{e}")
         send_mail(email_subject, email_message, email_recipients)
 
-    if len(ont_run.sync_finished_indicator) and os.path.isfile(ont_run.sync_finished_indicator[0]):
+    if os.path.isfile(ont_run.sync_finished_indicator):
         logger.info('Sequencing done for run {}. Attempting to start processing.'.format(ont_run.run_id))
         if ont_run.is_not_transferred():
             if ont_run.transfer_run():

--- a/taca/nanopore/minion.py
+++ b/taca/nanopore/minion.py
@@ -231,3 +231,12 @@ class MinIONdelivery(Nanopore):
         f = open(new_file, 'w')
         f.write(path_to_write)
         f.close()
+    
+    def write_finished_indicator(self):
+        """Write a hidden file to indicate 
+        when the finial rsync is finished."""
+        new_file = os.path.join(self.run_dir, '.sync_finished')
+        f = open(new_file, 'w')
+        f.write()
+        f.close()
+        return new_file

--- a/taca/nanopore/minion.py
+++ b/taca/nanopore/minion.py
@@ -3,6 +3,7 @@ import subprocess
 import shutil
 import glob
 import logging
+import pathlib
 
 from taca.nanopore.nanopore import Nanopore
 from taca.utils.config import CONFIG
@@ -228,15 +229,12 @@ class MinIONdelivery(Nanopore):
         new_file = os.path.join(self.run_dir, 'run_path.txt')
         proj, sample, run = self.run_dir.split('/')[-3:]
         path_to_write = os.path.join(proj, sample, run)
-        f = open(new_file, 'w')
-        f.write(path_to_write)
-        f.close()
+        with open(new_file, 'w') as f:
+            f.write(path_to_write)
     
     def write_finished_indicator(self):
         """Write a hidden file to indicate 
         when the finial rsync is finished."""
         new_file = os.path.join(self.run_dir, '.sync_finished')
-        f = open(new_file, 'w')
-        f.write('0')
-        f.close()
+        pathlib.Path(new_file).touch()
         return new_file

--- a/taca/nanopore/minion.py
+++ b/taca/nanopore/minion.py
@@ -237,6 +237,6 @@ class MinIONdelivery(Nanopore):
         when the finial rsync is finished."""
         new_file = os.path.join(self.run_dir, '.sync_finished')
         f = open(new_file, 'w')
-        f.write()
+        f.write('0')
         f.close()
         return new_file

--- a/taca/nanopore/ont_transfer.py
+++ b/taca/nanopore/ont_transfer.py
@@ -1,6 +1,6 @@
 import logging
 import shutil
-import glob
+import os
 
 from taca.nanopore.nanopore import Nanopore
 from taca.utils.config import CONFIG
@@ -12,7 +12,7 @@ class ONTTransfer(Nanopore):
     """Base class for transfer of ONT data to HPC cluster"""
     def __init__(self, run_dir):
         super(ONTTransfer, self).__init__(run_dir)
-        self.sync_finished_indicator = glob.glob(run_dir + '.sync_finished')
+        self.sync_finished_indicator = os.path.join(run_dir, '.sync_finished')
     
     def archive_run(self):
         """Move run directory to nosync."""

--- a/taca/nanopore/ont_transfer.py
+++ b/taca/nanopore/ont_transfer.py
@@ -1,5 +1,6 @@
 import logging
 import shutil
+import glob
 
 from taca.nanopore.nanopore import Nanopore
 from taca.utils.config import CONFIG
@@ -11,6 +12,7 @@ class ONTTransfer(Nanopore):
     """Base class for transfer of ONT data to HPC cluster"""
     def __init__(self, run_dir):
         super(ONTTransfer, self).__init__(run_dir)
+        self.sync_finished_indicator = glob.glob(run_dir + '.sync_finished')
     
     def archive_run(self):
         """Move run directory to nosync."""

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -69,7 +69,7 @@ def write_finished_indicator(run_path):
     when the finial rsync is finished."""
     new_file = os.path.join(run_path, '.sync_finished')
     f = open(new_file, 'w')
-    f.write()
+    f.write('0')
     f.close()
     return new_file
 

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -63,6 +63,15 @@ def dump_path(run_path):
     f = open(new_file, 'w')
     f.write(path_to_write)
     f.close()
+    
+def write_finished_indicator(run_path):
+    """Write a hidden file to indicate 
+    when the finial rsync is finished."""
+    new_file = os.path.join(run_path, '.sync_finished')
+    f = open(new_file, 'w')
+    f.write()
+    f.close()
+    return new_file
 
 def sync_to_storage(run_dir, destination, log_file):
     """Sync the run to storage using rsync. 
@@ -78,6 +87,9 @@ def final_sync_to_storage(run_dir, destination, archive_dir, log_file):
     command = ['run-one', 'rsync', '-rv', '--log-file=' + log_file, run_dir, destination]
     process_handle = subprocess.run(command)
     if process_handle.returncode == 0:
+        finished_indicator = write_finished_indicator(run_dir)
+        sync_finished_indicator = ['rsync', finished_indicator, destination]
+        process_handle = subprocess.run(sync_finished_indicator)
         archive_finished_run(run_dir, archive_dir)
     else:
         print('Previous rsync might be running still. Skipping {} for now.'.format(run_dir))

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -1,6 +1,6 @@
 """ Transfers new PromethION runs to ngi-nas using rsync.
 """
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 import os
 import shutil

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -43,7 +43,6 @@ def main(args):
         sync_to_storage(run, destination_dir, log_file)
     for run in finished:
         final_sync_to_storage(run, destination_dir, archive_dir, log_file) 
-        #TODO: possible improvement: Instead of waiting for the final sync, make it print the exit code to a file when done and use that as an indicator that the run is ready to archive. i.e. split the process into three steps instead of 2.
         
 
 def sequencing_finished(run_dir):
@@ -60,17 +59,14 @@ def dump_path(run_path):
     new_file = os.path.join(run_path, 'run_path.txt')
     proj, sample, run = run_path.split('/')[3:]
     path_to_write = os.path.join(proj, sample, run)
-    f = open(new_file, 'w')
-    f.write(path_to_write)
-    f.close()
+    with open(new_file, 'w') as f:
+        f.write(path_to_write)
     
 def write_finished_indicator(run_path):
     """Write a hidden file to indicate 
     when the finial rsync is finished."""
     new_file = os.path.join(run_path, '.sync_finished')
-    f = open(new_file, 'w')
-    f.write('0')
-    f.close()
+    pathlib.Path(new_file).touch()
     return new_file
 
 def sync_to_storage(run_dir, destination, log_file):

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -88,7 +88,8 @@ def final_sync_to_storage(run_dir, destination, archive_dir, log_file):
     process_handle = subprocess.run(command)
     if process_handle.returncode == 0:
         finished_indicator = write_finished_indicator(run_dir)
-        sync_finished_indicator = ['rsync', finished_indicator, destination]
+        dest = os.path.join(destination, os.path.basename(run_dir))
+        sync_finished_indicator = ['rsync', finished_indicator, dest]
         process_handle = subprocess.run(sync_finished_indicator)
         archive_finished_run(run_dir, archive_dir)
     else:


### PR DESCRIPTION
If the final rsync from promethion or squiggle takes more than an hour, the final_summary file might be picked up by taca on preproc1 before the final rsync is done, resulting in an incomplete transfer to uppmax. This should fix it.
