### PR TITLE
Fix minknow reports

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # TACA Version Log
 
+## 20230502.1
+Enforce MinKNOW reports retain MinKNOW run ID upon transfer to ngi-internal. Improve logging.
+
 ## 20230428.1
 Change offload location in promethion_transfer.py
 

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = '0.9.18'
+__version__ = "0.9.19"


### PR DESCRIPTION
ONT has rolled out a new naming convention for the .html-report files in which they do not contain the full run ID. This change will rename the files as they are transferred to ngi-internal to correspond to our existing conventions, so we don't have to change how the GenStat's back-end accesses the reports.

I've also improved some logging.