### PR TITLE
Promethion dump path fix

### DIFF
--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -46,6 +46,7 @@ def main(args):
         dump_path(run)
         sync_to_storage(run, destination_dir, log_file)
     for run in finished:
+        dump_path(run)  # To catch very small runs that finished quickly
         final_sync_to_storage(run, destination_dir, archive_dir, log_file) 
         
 

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -1,6 +1,6 @@
 """ Transfers new PromethION runs to ngi-nas using rsync.
 """
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 import os
 import re


### PR DESCRIPTION
If a PromethION run finishes very quickly, promethion_transfer.py would not create the path file before syncing. 