### PR TITLE
Quickfix to transfer reports of finished runs

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # TACA Version Log
 
+## 20230503.1
+Change how MinKNOW reports are synced to GenStat server to increase traceability and enable transfer of the reports of finished runs.
+
 ## 20230502.1
 Enforce MinKNOW reports retain MinKNOW run ID upon transfer to ngi-internal. Improve logging.
 

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = "0.9.20"
+__version__ = "0.9.21"


### PR DESCRIPTION
Needed some small refactoring to trigger TACA to sync reports of runs that are completely synced to the database.