### PR TITLE
Improve dir search of promethion transfer script

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # TACA Version Log
 
+## 20230711.1
+Rework how PromethION script detects runs to catch mis-named ones, too.
+
 ## 20230621.1
 Add support for NovaSeqXPlus and improve readability
 

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = "0.9.26"
+__version__ = "0.9.27"

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = "0.9.27"
+__version__ = "0.9.26"

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -8,6 +8,7 @@ import shutil
 import pathlib
 import argparse
 import subprocess
+from glob import glob
 
 def main(args):
     """Find promethion runs and transfer them to storage. 
@@ -18,18 +19,13 @@ def main(args):
     destination_dir = args.dest_dir
     archive_dir = args.archive_dir
     log_file = os.path.join(data_dir, 'rsync_log.txt')
-    found_top_dirs = [os.path.join(data_dir, top_dir) for top_dir in os.listdir(data_dir)
-            if os.path.isdir(os.path.join(data_dir, top_dir)) 
-            and (re.match(project_pattern, top_dir) or re.match(lims_id_pattern, top_dir))]
-    
-    runs = []
-    if found_top_dirs:
-        for top_dir in found_top_dirs:
-            if os.path.isdir(top_dir):
-                for sample_dir in os.listdir(top_dir):
-                    if os.path.isdir(os.path.join(top_dir, sample_dir)):
-                        for run_dir in os.listdir(os.path.join(top_dir, sample_dir)):
-                            runs.append(os.path.join(top_dir, sample_dir, run_dir))
+
+    run_pattern = re.compile("\d{8}_\d{4}_[A-Za-z0-9]+_[A-Za-z0-9]+_[A-Za-z0-9]+")
+    runs = [
+        path
+        for path in glob("*/*/*", recursive=True)
+        if re.match(run_pattern, os.path.basename(path))
+    ]
     
     # Split finished and unfinished runs
     not_finished = []

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -1,6 +1,6 @@
 """ Transfers new PromethION runs to ngi-nas using rsync.
 """
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 import os
 import re
@@ -14,8 +14,6 @@ def main(args):
     """Find promethion runs and transfer them to storage. 
     Archives the run when the transfer is complete."""
     data_dir = args.source_dir
-    project_pattern = re.compile("^P\d{4,6}$")  # Runs started manually (project ID)
-    lims_id_pattern = re.compile("^24-\d{6}$")  # Runs started with samplesheet (lims ID)
     destination_dir = args.dest_dir
     archive_dir = args.archive_dir
     log_file = os.path.join(data_dir, 'rsync_log.txt')


### PR DESCRIPTION
It's happened one too many times now that operators have misnamed sequencing runs, leading to them not being picked up. Even if it's just a test run, we'd want to e.g. record the metadata properly which is only done if the run is synced to the preproc.