### PR TITLE
Automate collection of ONT QC metrics

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # TACA Version Log
 
+## 20230713.1
+Let PromethION script search through device logs to dump flow cell pore count history into the run dir.
+
 ## 20230711.1
 Rework how PromethION script detects runs to catch mis-named ones, too.
 

--- a/taca/analysis/analysis_nanopore.py
+++ b/taca/analysis/analysis_nanopore.py
@@ -386,8 +386,18 @@ def ont_updatedb(ont_run):
             logger.info(
                 f"Run {ont_run.run_id} does not exist in the database, creating entry for ongoing run."
             )
+
             run_path_file = os.path.join(ont_run.run_dir, "run_path.txt")
-            sesh.create_ongoing_run(ont_run, open(run_path_file, "r").read().strip())
+            assert os.path.isfile(run_path_file), f"Couldn't find {run_path_file}"
+
+            pore_count_history_file = os.path.join(
+                ont_run.run_dir, "pore_count_history.csv"
+            )
+            assert os.path.isfile(
+                pore_count_history_file
+            ), f"Couldn't find {pore_count_history_file}"
+
+            sesh.create_ongoing_run(ont_run, run_path_file, pore_count_history_file)
             logger.info(
                 f"Successfully created db entry for ongoing run {ont_run.run_id}."
             )

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -1,6 +1,6 @@
 """ Transfers new PromethION runs to ngi-nas using rsync.
 """
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 import os
 import re

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -115,7 +115,7 @@ def archive_finished_run(run_dir, archive_dir):
 
 
 def parse_position_logs(minknow_log_dir: str) -> list:
-    """Look through all flow cell position logs and boil down into a strucutred list of dicts
+    """Look through all flow cell position logs and boil down into a structured list of dicts
 
     Example output:
     [{

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -219,17 +219,20 @@ def dump_pore_count_history(run, pore_counts):
         )
     ]
 
-    flowcell_pore_counts_sorted = sorted(
-        flowcell_pore_counts, key=lambda x: x["timestamp"], reverse=True
-    )
+    if flowcell_pore_counts:
+        flowcell_pore_counts_sorted = sorted(
+            flowcell_pore_counts, key=lambda x: x["timestamp"], reverse=True
+        )
 
-    header = flowcell_pore_counts_sorted[0].keys()
-    rows = [e.values() for e in flowcell_pore_counts_sorted]
+        header = flowcell_pore_counts_sorted[0].keys()
+        rows = [e.values() for e in flowcell_pore_counts_sorted]
 
-    with open(new_file_path, "w") as f:
-        f.write(",".join(header) + "\n")
-        for row in rows:
-            f.write(",".join(row) + "\n")
+        with open(new_file_path, "w") as f:
+            f.write(",".join(header) + "\n")
+            for row in rows:
+                f.write(",".join(row) + "\n")
+    else:
+        open(new_file_path, "a").close()
 
 
 if __name__ == "__main__":

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -14,13 +14,11 @@ def main(args):
     """Find promethion runs and transfer them to storage. 
     Archives the run when the transfer is complete."""
     data_dir = args.source_dir
-    project_pattern = re.compile("^P\d{4,6}$")  # Runs started manually (project ID)
-    lims_id_pattern = re.compile("^24-\d{6}$")  # Runs started with samplesheet (lims ID)
+    run_pattern = re.compile("\d{8}_\d{4}_[A-Za-z0-9]+_[A-Za-z0-9]+_[A-Za-z0-9]+")
     destination_dir = args.dest_dir
     archive_dir = args.archive_dir
     log_file = os.path.join(data_dir, 'rsync_log.txt')
 
-    run_pattern = re.compile("\d{8}_\d{4}_[A-Za-z0-9]+_[A-Za-z0-9]+_[A-Za-z0-9]+")
     runs = [
         path
         for path in glob("*/*/*", recursive=True)
@@ -36,13 +34,12 @@ def main(args):
             finished.append(run)
         else:
             not_finished.append(run)
+        dump_path(run)
 
     # Start transfer of unfinished runs first (detatched)
     for run in not_finished:
-        dump_path(run)
         sync_to_storage(run, destination_dir, log_file)
     for run in finished:
-        dump_path(run)  # To catch very small runs that finished quickly
         final_sync_to_storage(run, destination_dir, archive_dir, log_file) 
         
 

--- a/taca/nanopore/promethion_transfer.py
+++ b/taca/nanopore/promethion_transfer.py
@@ -208,7 +208,7 @@ def dump_pore_count_history(run, pore_counts):
     run_start_time = dt.strptime(os.path.basename(run)[0:13], "%Y%m%d_%H%M")
     log_time_pattern = "%Y-%m-%d %H:%M:%S.%f"
 
-    new_file_path = os.path.join(run, f"{flowcell_id}_pore_count_history.csv")
+    new_file_path = os.path.join(run, "pore_count_history.csv")
 
     flowcell_pore_counts = [
         log_entry

--- a/taca/utils/statusdb.py
+++ b/taca/utils/statusdb.py
@@ -3,6 +3,7 @@
 import couchdb
 import logging
 from datetime import datetime
+import csv
 
 logger = logging.getLogger(__name__)
 
@@ -105,8 +106,20 @@ class NanoporeRunsConnection(StatusdbSession):
         doc_id = view_all_stats[ont_run.run_id].rows[0].id
         return self.db[doc_id]["run_status"]
 
-    def create_ongoing_run(self, ont_run, extended_run_path):
-        new_doc = {"run_path": extended_run_path, "run_status": "ongoing"}
+    def create_ongoing_run(self, ont_run, run_path_file, pore_count_history_file):
+
+        run_path = open(run_path_file, "r").read().strip()
+
+        pore_counts = []
+        with open(pore_count_history_file, "r") as stream:
+            for line in csv.DictReader(stream):
+                pore_counts.append(line)
+
+        new_doc = {
+            "run_path": run_path,
+            "run_status": "ongoing",
+            "pore_count_history": pore_counts,
+        }
 
         new_doc_id, new_doc_rev = self.db.save(new_doc)
         logger.info(f"New database entry created: {ont_run.run_id}, id {new_doc_id}, rev {new_doc_rev}")


### PR DESCRIPTION
For a new sequencing run, the PromethION script will now go through the instrument logs to find all previous pore counts recorded for the running flowcell, either from flow cell QC or sequencing MUX scans. This information will be dumped in the sequencing run directory (same as the run_path.txt).

TACA will then parse this information and append it to the CouchDB entry.

:)