### PR TITLE
Adapt MinKNOW .json trimming to new format from Dorado update

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # TACA Version Log
 
+## 20230903.1
+Adapt MinKNOW .json trimming to new format from Dorado update.
+
 ## 20230823.1
 Allow manual database update of finished ONT runs
 

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,4 +1,4 @@
 """ Main TACA module
 """
 
-__version__ = "0.9.31"
+__version__ = "0.9.32"

--- a/taca/nanopore/nanopore.py
+++ b/taca/nanopore/nanopore.py
@@ -291,7 +291,6 @@ class Nanopore(object):
 
         # These sections of the .json can be added as they are
         for section in [
-            "software_versions",
             "host",
             "protocol_run_info",
             "user_messages",


### PR DESCRIPTION
The .json section "software_versions" is now nested within another section already included in the parsing, so it can be omitted.

This issue cause TACA to throw an error for run 20230828_1224_3A_PAO31621_af226024.

The run was properly synced to StatusDB today by running a manual database update of the run locally. The metadata is yet to be synced to ngi-nas-ns/promethion_data.