### PR TITLE
Implement CodeCoverage

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -21,3 +23,10 @@ jobs:
       - name: pytest
         # Options are configured in pyproject.toml
         run: pytest
+      - name: CodeCov
+        run: |
+          # Replace `linux` below with the appropriate OS
+          # Options are `alpine`, `linux`, `macos`, `windows`
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -t ${{ secrets.CODECOV_TOKEN }}

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20240209.1
+
+Implement CodeCoverage in CI.
+
 ## 20240208.2
 
 Implement CI testing and increase testing coverage.


### PR DESCRIPTION
I merged #415 into a dev branch here on upstream to make the secrets accessible.

Now this PR `upstream/master <-- upstream/codecov` can be used to evaluate whether the GitHub Actions work as intended.