### PR TITLE
Change db names

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # TACA Version Log
 
+## 20240418.1
+Removed dbname option from classes where it was not used. Renamed StatusDB database variables to attempt to standardise them.
+
 ## 20240410.1
 
 Expand test coverage by starting and checking demultiplexing for a NovaSeqXPlus run.

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,7 +1,8 @@
 # TACA Version Log
 
 ## 20240418.1
-Removed dbname option from classes where it was not used. Renamed StatusDB database variables to attempt to standardise them.
+
+Removed dbname option from classes where it was not used. Renamed StatusDB database variables to attempt to standardize them.
 
 ## 20240410.1
 

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -110,7 +110,7 @@ def _upload_to_statusdb(run):
     """
     couch_conf = CONFIG["statusdb"]
     couch_connection = statusdb.StatusdbSession(couch_conf).connection
-    db = couch_connection[couch_conf["xten_db"]]
+    x_flowcells_db = couch_connection[couch_conf["xten_db"]]
     parser = run.runParserObj
     # Check if I have NoIndex lanes
     for element in parser.obj["samplesheet_csv"]:
@@ -155,7 +155,7 @@ def _upload_to_statusdb(run):
         parser.obj["DemultiplexConfig"] = {
             "Setup": {"Software": run.CONFIG.get("bcl2fastq", {})}
         }
-    statusdb.update_doc(db, parser.obj, over_write_db_entry=True)
+    statusdb.update_doc(x_flowcells_db, parser.obj, over_write_db_entry=True)
 
 
 def transfer_run(run_dir, software):

--- a/taca/backup/backup.py
+++ b/taca/backup/backup.py
@@ -265,12 +265,14 @@ class backup_utils:
                 run_date = run_vals[0]
             run_fc = f"{run_date}_{run_vals[-1]}"
             couch_connection = statusdb.StatusdbSession(self.couch_info).connection
-            db = couch_connection[self.couch_info["db"]]
-            fc_names = {e.key: e.id for e in db.view("names/name", reduce=False)}
+            x_flowcells_db = couch_connection[self.couch_info["db"]]
+            fc_names = {
+                e.key: e.id for e in x_flowcells_db.view("names/name", reduce=False)
+            }
             d_id = fc_names[run_fc]
-            doc = db.get(d_id)
+            doc = x_flowcells_db.get(d_id)
             doc["pdc_archived"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            db.save(doc)
+            x_flowcells_db.save(doc)
             logger.info(
                 f'Logged "pdc_archived" timestamp for fc {run} in statusdb doc "{d_id}"'
             )

--- a/taca/utils/bioinfo_tab.py
+++ b/taca/utils/bioinfo_tab.py
@@ -55,8 +55,8 @@ def update_statusdb(run_dir):
     statusdb_conf = CONFIG.get("statusdb")
     couch_connection = statusdb.StatusdbSession(statusdb_conf).connection
     valueskey = datetime.datetime.now().isoformat()
-    db = couch_connection["bioinfo_analysis"]
-    view = db.view("latest_data/sample_id")
+    bioinfo_db = couch_connection["bioinfo_analysis"]
+    view = bioinfo_db.view("latest_data/sample_id")
     # Construction and sending of individual records, if samplesheet is incorrectly formatted the loop is skipped
     if project_info:
         for flowcell in project_info:
@@ -87,8 +87,8 @@ def update_statusdb(run_dir):
                         if len(view[[project, run_id, lane, sample]].rows) >= 1:
                             remote_id = view[[project, run_id, lane, sample]].rows[0].id
                             lane = str(lane)
-                            remote_doc = db[remote_id]["values"]
-                            remote_status = db[remote_id]["status"]
+                            remote_doc = bioinfo_db[remote_id]["values"]
+                            remote_status = bioinfo_db[remote_id]["status"]
                             # Only updates the listed statuses
                             if (
                                 remote_status
@@ -110,16 +110,16 @@ def update_statusdb(run_dir):
                                     )
                                 )
                                 # Update record cluster
-                                obj["_rev"] = db[remote_id].rev
+                                obj["_rev"] = bioinfo_db[remote_id].rev
                                 obj["_id"] = remote_id
-                                db.save(obj)
+                                bioinfo_db.save(obj)
                         # Creates new entry
                         else:
                             logger.info(
                                 f"Creating {run_id} {project} {flowcell} {lane} {sample} as {sample_status}"
                             )
                             # Creates record
-                            db.save(obj)
+                            bioinfo_db.save(obj)
                         # Sets FC error flag
                         if project_info[flowcell].value is not None:
                             if (

--- a/taca/utils/misc.py
+++ b/taca/utils/misc.py
@@ -214,11 +214,11 @@ def run_is_demuxed(run, couch_info=None, seq_run_type=None):
         run_name = f"{run_date}_{run_fc}"
         try:
             couch_connection = statusdb.StatusdbSession(couch_info).connection
-            fc_db = couch_connection[couch_info["xten_db"]]
-            for fc in fc_db.view("names/name", reduce=False, descending=True):
+            x_flowcells_db = couch_connection[couch_info["xten_db"]]
+            for fc in x_flowcells_db.view("names/name", reduce=False, descending=True):
                 if fc.key != run_name:
                     continue
-                fc_doc = fc_db.get(fc.id)
+                fc_doc = x_flowcells_db.get(fc.id)
                 if not fc_doc or not fc_doc.get("illumina", {}).get(
                     "Demultiplex_Stats", {}
                 ):


### PR DESCRIPTION
An effort to standardise variable names that refers to a single specific StatusDB database.

In a few cases, I have dropped the option `dbname` to some classes, I've checked with taca-ngi-pipeline as well that these options were not used. Might need to check elsewhere as well if these classes are used there.