### PR TITLE
Broaden ONT transfer script's categorization of QC runs

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20240507.1
+
+Broaden ONT transfer script's categorization of QC runs to either experiment dir or sample dir starting with "QC\_".
+
 ## 20240422.1
 
 Refine GHA VERSIONLOG.md check to compare to merge-base, not branch-base.

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -50,8 +50,9 @@ def main(args):
     for run_path in run_paths:
         logging.info(f"Handling {run_path}...")
 
-        if run_path.split(os.sep)[-2][0:3] == "QC_":
-            # For QC runs, the sample name should start with "QC_"
+        experiment_name = run_path.split(os.sep)[-3]
+        sample_name = run_path.split(os.sep)[-2]
+        if sample_name[0:3] == "QC_" or experiment_name[0:3] == "QC_":
             logging.info("Run categorized as QC.")
             rsync_dest = args.dest_dir_qc
         else:

--- a/taca/utils/misc.py
+++ b/taca/utils/misc.py
@@ -162,7 +162,7 @@ def query_yes_no(question, default="yes", force=False):
     elif default == "no":
         prompt = " [y/N] "
     else:
-        raise ValueError('invalid default answer: "%s"' % default)
+        raise ValueError(f'invalid default answer: "{default}"')
 
     while True:
         sys.stdout.write(question + prompt)


### PR DESCRIPTION
Broaden ONT transfer script's categorization of QC runs to either experiment dir or sample dir starting with "QC_".

Sneakily pre-deployed on pelagos to prevent ongoing sync of run [20240507_1448_MN19414_ATD545_be1c9e17](https://genomics-status.scilifelab.se/flowcells_ont/20240507_1448_MN19414_ATD545_be1c9e17) from being messed up.