### PR TITLE
update anglerfish command used

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20240816.1
+
+Update command used to run Anglerfish.
+
 ## 20240705.1
 
 Add section header in samplesheet for run folder transfer

--- a/taca/nanopore/ONT_run_classes.py
+++ b/taca/nanopore/ONT_run_classes.py
@@ -530,10 +530,12 @@ class ONT_qc_run(ONT_run):
 
         anglerfish_command = [
             self.anglerfish_path,
+            "run",
             f"--samplesheet {self.anglerfish_samplesheet}",
             f"--out_fastq {self.run_abspath}",
             f"--run_name {anglerfish_run_name}",
             f"--threads {n_threads}",
+            "--max_distance 1",
             "--lenient",
             "--skip_demux",
         ]


### PR DESCRIPTION
Use the `run` subcommand and allow index distances to be as low as 1, as has been the case for many QC runs.