### PR TITLE
Organising flowcell data on Miarka

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20241127.1
+
+Add support for organising ONT data on Miarka
+
 ## 20241112.1
 
 Add support for backing up Element Aviti data to PDC

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
             "server_status = taca.server_status.cli:server_status",
             "backup = taca.backup.cli:backup",
             "create_env = taca.testing.cli:uppmax_env",
+            "organise = taca.organise.cli:organise_flowcells",
         ],
     },
     install_requires=install_requires,

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,3 +1,3 @@
 """Main TACA module"""
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"

--- a/taca/backup/backup.py
+++ b/taca/backup/backup.py
@@ -69,7 +69,7 @@ class backup_utils:
             archive_path = self.archive_dirs[run_type]
             run = run_vars(self.run, archive_path)
             if not (
-                re.match(filesystem.RUN_RE, run.name)
+                re.match(filesystem.RUN_RE_ILLUMINA, run.name)
                 or re.match(filesystem.RUN_RE_ONT, run.name)
                 or re.match(filesystem.RUN_RE_ELEMENT, run.name)
             ):
@@ -92,7 +92,7 @@ class backup_utils:
                     elif not os.path.isdir(os.path.join(archive_dir, item)):
                         continue
                     if (
-                        re.match(filesystem.RUN_RE, item)
+                        re.match(filesystem.RUN_RE_ILLUMINA, item)
                         or re.match(filesystem.RUN_RE_ONT, item)
                         or re.match(filesystem.RUN_RE_ELEMENT, item)
                     ) and item not in self.runs:
@@ -121,7 +121,7 @@ class backup_utils:
                 continue
             for run_dir in os.listdir(data_dir):
                 if not (
-                    re.match(filesystem.RUN_RE, run_dir)
+                    re.match(filesystem.RUN_RE_ILLUMINA, run_dir)
                     or re.match(filesystem.RUN_RE_ONT, run_dir)
                     or re.match(filesystem.RUN_RE_ELEMENT, run_dir)
                 ):

--- a/taca/cleanup/cleanup.py
+++ b/taca/cleanup/cleanup.py
@@ -118,7 +118,9 @@ def cleanup_miarka(
         all_undet_files = []
         for flowcell_dir in flowcell_dir_root:
             for fc in [
-                d for d in os.listdir(flowcell_dir) if re.match(filesystem.RUN_RE, d)
+                d
+                for d in os.listdir(flowcell_dir)
+                if re.match(filesystem.RUN_RE_ILLUMINA, d)
             ]:
                 fc_abs_path = os.path.join(flowcell_dir, fc)
                 with filesystem.chdir(fc_abs_path):
@@ -187,7 +189,9 @@ def cleanup_miarka(
     else:
         for flowcell_dir in flowcell_dir_root:
             for fc in [
-                d for d in os.listdir(flowcell_dir) if re.match(filesystem.RUN_RE, d)
+                d
+                for d in os.listdir(flowcell_dir)
+                if re.match(filesystem.RUN_RE_ILLUMINA, d)
             ]:
                 fc_abs_path = os.path.join(flowcell_dir, fc)
                 with filesystem.chdir(fc_abs_path):

--- a/taca/organise/cli.py
+++ b/taca/organise/cli.py
@@ -12,7 +12,7 @@ from taca.organise import organise
     type=str,
     required=True,
     help="Project ID (e.g. P12345)",
-)
+) # future todo: option to organise all flowcells in a project
 @click.argument("flowcells")
 def organise_flowcells(flowcells, project):
     """Organise FLOWCELLS.

--- a/taca/organise/cli.py
+++ b/taca/organise/cli.py
@@ -12,7 +12,7 @@ from taca.organise import organise
     type=str,
     required=True,
     help="Project ID (e.g. P12345)",
-) # future todo: option to organise all flowcells in a project
+)  # future todo: option to organise all flowcells in a project
 @click.argument("flowcells")
 def organise_flowcells(flowcells, project):
     """Organise FLOWCELLS.

--- a/taca/organise/cli.py
+++ b/taca/organise/cli.py
@@ -1,0 +1,25 @@
+"""CLI for the organise subcommand."""
+
+import click
+
+from taca.organise import organise
+
+
+@click.command(name="organise")
+@click.option(
+    "-p",
+    "--project",
+    type=str,
+    required=True,
+    help="Project ID (e.g. P12345)",
+)
+@click.argument("flowcells")
+def organise_flowcells(flowcells, project):
+    """Organise FLOWCELLS.
+
+    FLOWCELLS is the name of one or more sequencing flowcells, separated by a comma. e.g.:
+    241122_VH00204_464_AAG77JJN5,241120_VH00202_453_AAG76JJM7
+    """
+    flowcells_to_organise = flowcells.split(",")
+    for fc in flowcells_to_organise:
+        organise.organise_flowcell(fc, project)

--- a/taca/organise/flowcells.py
+++ b/taca/organise/flowcells.py
@@ -4,9 +4,28 @@ import logging
 import os
 
 from taca.utils.config import CONFIG
+from taca.utils.misc import call_external_command_detached
 
 logger = logging.getLogger(__name__)
 
+def get_flowcell_type(flowcell):
+    """Return flowcell type based on flowcell name"""
+    pass
+
+def instantiate_flowcell(flowcell, project):
+    flowcell_type = get_flowcell_type(flowcell)
+
+    if flowcell_type == "nanopore":
+        return NanoporeFlowcell(flowcell=flowcell, project_id=project)
+    elif flowcell_type == "illumina":
+        return IlluminaFlowcell(flowcell=flowcell, project_id=project)
+    elif flowcell_type == "element":
+        return ElementFlowcell(flowcell=flowcell, project_id=project)
+    else:
+        logger.warning(
+            f"Flowcell type could not be recognised for flowcell {flowcell}, skipping it."
+        )
+        return
 
 class Flowcell:
     """Defines a generic Flowcell"""
@@ -36,7 +55,9 @@ class NanoporeFlowcell(Flowcell):
     def organise_data(self):
         """Tarball data into ONT_TAR"""
         # generate tarball (detached process? how to signal when tarballing is done?)
-        pass
+        # future todo: also organise data in DATA for easier analysis
+        tar_command = f'tar -cf {self.fc_id}'
+        call_external_command_detached(tar_command)
 
 
 class IlluminaFlowcell(Flowcell):

--- a/taca/organise/flowcells.py
+++ b/taca/organise/flowcells.py
@@ -78,7 +78,9 @@ class NanoporeFlowcell(Flowcell):
                     f.write(result.stdout)
                 logger.info(f"Finished generating md5sum for {self.fc_id}.")
             except subprocess.CalledProcessError as e:
-                logger.error(f"An error occurred while generating the md5sum for {self.fc_id}.")
+                logger.error(
+                    f"An error occurred while generating the md5sum for {self.fc_id}."
+                )
                 raise e
         # TODO: Add a timestamp to statusdb indicating when the FC was organised
 

--- a/taca/organise/flowcells.py
+++ b/taca/organise/flowcells.py
@@ -55,6 +55,7 @@ class NanoporeFlowcell(Flowcell):
     def organise_data(self):
         """Tarball data into ONT_TAR"""
         # future todo: also organise data in DATA for easier analysis
+        # future todo: make a list of samples included in the tarball
         tar_err = os.path.join(self.organised_project_dir, "tar.err")
         with filesystem.chdir(self.incoming_path):
             try:

--- a/taca/organise/flowcells.py
+++ b/taca/organise/flowcells.py
@@ -1,0 +1,63 @@
+"""Flowcell classes for TACA."""
+
+import logging
+import os
+
+from taca.utils.config import CONFIG
+
+logger = logging.getLogger(__name__)
+
+
+class Flowcell:
+    """Defines a generic Flowcell"""
+
+    def __init__(self, flowcell, project_id):
+        self.fc_id = flowcell
+        self.project_id = project_id
+        self.detsination_path = CONFIG.get("organise", None).get(
+            self.fc_type + "_path", None
+        )
+        self.organised_project_dir = os.path.join(self.detsination_path, project_id)
+
+    def create_org_dir(self):
+        """Create a project directory that the data should be organised to."""
+        if not os.path.exists(self.organised_project_dir):
+            os.mkdir(self.organised_project_dir)
+        return
+
+
+class NanoporeFlowcell(Flowcell):
+    """Defines a Nanopore Flowcell"""
+
+    def __init__(self, flowcell, project_id):
+        super().__init__(flowcell, project_id)
+        self.fc_type = "nanopore"
+
+    def organise_data(self):
+        """Tarball data into ONT_TAR"""
+        # generate tarball (detached process? how to signal when tarballing is done?)
+        pass
+
+
+class IlluminaFlowcell(Flowcell):
+    """Defines a Illumina Flowcell"""
+
+    def __init__(self, flowcell, project_id):
+        super().__init__(flowcell, project_id)
+        self.fc_type = "illumina"
+
+    def organise_data(self):
+        """Symlink data into DATA"""
+        pass
+
+
+class ElementFlowcell(Flowcell):
+    """Defines a Element Flowcell"""
+
+    def __init__(self, flowcell):
+        super().__init__(flowcell)
+        self.fc_type = "element"
+
+    def organise_data(self):
+        """Symlink data into DATA"""
+        pass

--- a/taca/organise/flowcells.py
+++ b/taca/organise/flowcells.py
@@ -60,17 +60,18 @@ class NanoporeFlowcell(Flowcell):
         with filesystem.chdir(self.incoming_path):
             try:
                 tar_command = ["tar", "-cvf", self.tar_path, self.fc_id]
-                subprocess.run(tar_command)  # TODO: catch out and err in files
+                result = subprocess.run(tar_command, capture_output=True, text=True)
+                tar_err = os.path.join(self.organised_project_dir, "tar.err")
+                with open(tar_err, "w") as f:
+                    f.write(result.stderr)
             except subprocess.CalledProcessError as e:
                 raise e
         with filesystem.chdir(self.organised_project_dir):
             try:
                 md5_command = ["md5sum", self.tar_file]
-                result = subprocess.run(
-                    md5_command, capture_output=True, text=True
-                )  # TODO: catch err in files
-                with open(self.md5_path, "w") as md5_file:
-                    md5_file.write(result.stdout)
+                result = subprocess.run(md5_command, capture_output=True, text=True)
+                with open(self.md5_path, "w") as f:
+                    f.write(result.stdout)
             except subprocess.CalledProcessError as e:
                 raise e
         # TODO: Add a timestamp to statusdb indicating when the FC was organised

--- a/taca/organise/organise.py
+++ b/taca/organise/organise.py
@@ -2,16 +2,14 @@
 
 import logging
 
-from taca.organise.flowcells import instantiate_flowcell
+from taca.organise.flowcells import get_flowcell_object
 
 logger = logging.getLogger(__name__)
 
 
 def organise_flowcell(flowcell, project):
     """Determine flowcell type and organise the data accordingly."""
-    flowcell_object = instantiate_flowcell()
-
+    flowcell_object = get_flowcell_object(flowcell, project)
     flowcell_object.create_org_dir()
     flowcell_object.organise_data()
-
     logger.info(f"Finished organisation of flowcell {flowcell}.")

--- a/taca/organise/organise.py
+++ b/taca/organise/organise.py
@@ -2,31 +2,14 @@
 
 import logging
 
-from taca.organise.flowcells import ElementFlowcell, IlluminaFlowcell, NanoporeFlowcell
+from taca.organise.flowcells import instantiate_flowcell
 
 logger = logging.getLogger(__name__)
 
 
-def get_flowcell_type(flowcell):
-    """Return flowcell type based on flowcell name"""
-    pass
-
-
 def organise_flowcell(flowcell, project):
     """Determine flowcell type and organise the data accordingly."""
-    flowcell_type = get_flowcell_type(flowcell)
-
-    if flowcell_type == "nanopore":
-        flowcell_object = NanoporeFlowcell(flowcell=flowcell, project_id=project)
-    elif flowcell_type == "illumina":
-        flowcell_object = IlluminaFlowcell(flowcell=flowcell, project_id=project)
-    elif flowcell_type == "element":
-        flowcell_object = ElementFlowcell(flowcell=flowcell, project_id=project)
-    else:
-        logger.warning(
-            f"Flowcell type could not be recognised for flowcell {flowcell}, skipping it."
-        )
-        return
+    flowcell_object = instantiate_flowcell()
 
     flowcell_object.create_org_dir()
     flowcell_object.organise_data()

--- a/taca/organise/organise.py
+++ b/taca/organise/organise.py
@@ -1,0 +1,34 @@
+"""Flowcell organisation methods for TACA."""
+
+import logging
+
+from taca.organise.flowcells import ElementFlowcell, IlluminaFlowcell, NanoporeFlowcell
+
+logger = logging.getLogger(__name__)
+
+
+def get_flowcell_type(flowcell):
+    """Return flowcell type based on flowcell name"""
+    pass
+
+
+def organise_flowcell(flowcell, project):
+    """Determine flowcell type and organise the data accordingly."""
+    flowcell_type = get_flowcell_type(flowcell)
+
+    if flowcell_type == "nanopore":
+        flowcell_object = NanoporeFlowcell(flowcell=flowcell, project_id=project)
+    elif flowcell_type == "illumina":
+        flowcell_object = IlluminaFlowcell(flowcell=flowcell, project_id=project)
+    elif flowcell_type == "element":
+        flowcell_object = ElementFlowcell(flowcell=flowcell, project_id=project)
+    else:
+        logger.warning(
+            f"Flowcell type could not be recognised for flowcell {flowcell}, skipping it."
+        )
+        return
+
+    flowcell_object.create_org_dir()
+    flowcell_object.organise_data()
+
+    logger.info(f"Finished organisation of flowcell {flowcell}.")

--- a/taca/utils/filesystem.py
+++ b/taca/utils/filesystem.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 import shutil
 
-RUN_RE = r"^\d{6,8}_[a-zA-Z\d\-]+_\d{2,}_[AB0][A-Z\d\-]+$"
+RUN_RE_ILLUMINA = r"^\d{6,8}_[a-zA-Z\d\-]+_\d{2,}_[AB0][A-Z\d\-]+$"
 RUN_RE_ONT = r"^(\d{8})_(\d{4})_([0-9a-zA-Z]+)_([0-9a-zA-Z]+)_([0-9a-zA-Z]+)$"
 RUN_RE_ELEMENT = r"^\d{8}_AV\d{6}_[AB]\d{10}$"
 

--- a/tests/element/test_Element_Runs.py
+++ b/tests/element/test_Element_Runs.py
@@ -552,9 +552,12 @@ class TestRun:
 
     def test_start_demux(self, mock_db, create_dirs):
         tmp: tempfile.TemporaryDirectory = create_dirs
-        with mock.patch("subprocess.Popen") as mock_Popen, mock.patch(
-            "taca.element.Element_Runs.Run.generate_demux_command"
-        ) as mock_command:
+        with (
+            mock.patch("subprocess.Popen") as mock_Popen,
+            mock.patch(
+                "taca.element.Element_Runs.Run.generate_demux_command"
+            ) as mock_command,
+        ):
             mock_command.return_value = "test command"
             run = to_test.Run(create_element_run_dir(create_dirs), get_config(tmp))
             run.start_demux("mock_run_manifest", "mock_demux_dir")


### PR DESCRIPTION
Organising flowcell data in incoming on Miarka. Running `taca organise -p PID FC1,FC2...` should:

1. recognise flowcell type (illumina/nanopore/element)
2. create the destination project folder if it does not exist (DATA/PID or ONT_TAR/PID)
3. For ONT: tarball the data into the dest folder and calculate md5sum
4. For Illumina/element: symlink files in the required structure into the dest folder
