### PR TITLE
Fix for tar warning message when transferring run folders

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20260421.1
+
+Fix tar warning message
+
 ## 20260310.1
 
 Fix minor bugs for Aviti and ONT backup

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,3 +1,3 @@
 """Main TACA module"""
 
-__version__ = "1.6.19"
+__version__ = "1.6.20"

--- a/taca/analysis/analysis.py
+++ b/taca/analysis/analysis.py
@@ -271,7 +271,14 @@ def transfer_runfolder(run_dir, pid, exclude_lane):
         subprocess.call(
             ["tar"]
             + exclude_options_for_tar
-            + ["-cvf", archive, "-C", run_dir_path, dir_name]
+            + [
+                "-cvf",
+                archive,
+                "--warning=no-file-changed",
+                "-C",
+                run_dir_path,
+                dir_name,
+            ]
         )
     except subprocess.CalledProcessError as e:
         logger.error("Error creating tar archive")


### PR DESCRIPTION
Add `--warning=no-file-changed` option to tar process