### PR TITLE
Ignore runs that have not started sequencing

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,9 @@
 # TACA Version Log
 
+## 20260626.1
+
+ONT transfer script fix: don't sync runs that didn't start
+
 ## 20260421.1
 
 Fix tar warning message

--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -4,6 +4,10 @@
 
 ONT transfer script fix: don't sync runs that didn't start
 
+## 20260428.1
+
+Remove upper bound on magnitude of project and sample numbers
+
 ## 20260421.1
 
 Fix tar warning message

--- a/taca/__init__.py
+++ b/taca/__init__.py
@@ -1,3 +1,3 @@
 """Main TACA module"""
 
-__version__ = "1.6.21"
+__version__ = "1.6.22"

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -59,7 +59,11 @@ def handle_runs(run_paths, args):
     # Iterate over runs
     for run_path in run_paths:
         logging.info(f"Processing run at '{run_path}'")
-
+        # To prevent syncing runs that failed to start sequencing, skip run if none of the following directories exist: "fastq_fail", "fastq_pass", "bam_fail", "bam_pass"
+        required_dirs = ["fastq_fail", "fastq_pass", "bam_fail", "bam_pass"]
+        if not any(os.path.exists(os.path.join(run_path, d)) for d in required_dirs):
+            logging.info(f"{os.path.basename(run_path)}: Skipping run as none of the required directories exist.")
+            continue
         dump_path(run_path)
         dump_pore_count_history(run_path=run_path, pore_counts=pore_counts)
 

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -59,8 +59,8 @@ def handle_runs(run_paths, args):
     # Iterate over runs
     for run_path in run_paths:
         logging.info(f"Processing run at '{run_path}'")
-        # To prevent syncing runs that failed to start sequencing, skip run if none of the following directories exist: "fastq_fail", "fastq_pass", "bam_fail", "bam_pass"
-        required_dirs = ["fastq_fail", "fastq_pass", "bam_fail", "bam_pass"]
+        # To prevent syncing runs that failed to start sequencing, skip run if none of the following directories exist: "fastq_fail", "fastq_pass", "bam_fail", "bam_pass", "pod5_fail", "pod5_pass"
+        required_dirs = ["fastq_fail", "fastq_pass", "bam_fail", "bam_pass", "pod5_fail", "pod5_pass"]
         if not any(os.path.exists(os.path.join(run_path, d)) for d in required_dirs):
             logging.info(f"{os.path.basename(run_path)}: Skipping run as none of the required directories exist.")
             continue

--- a/taca/nanopore/instrument_transfer.py
+++ b/taca/nanopore/instrument_transfer.py
@@ -60,9 +60,18 @@ def handle_runs(run_paths, args):
     for run_path in run_paths:
         logging.info(f"Processing run at '{run_path}'")
         # To prevent syncing runs that failed to start sequencing, skip run if none of the following directories exist: "fastq_fail", "fastq_pass", "bam_fail", "bam_pass", "pod5_fail", "pod5_pass"
-        required_dirs = ["fastq_fail", "fastq_pass", "bam_fail", "bam_pass", "pod5_fail", "pod5_pass"]
+        required_dirs = [
+            "fastq_fail",
+            "fastq_pass",
+            "bam_fail",
+            "bam_pass",
+            "pod5_fail",
+            "pod5_pass",
+        ]
         if not any(os.path.exists(os.path.join(run_path, d)) for d in required_dirs):
-            logging.info(f"{os.path.basename(run_path)}: Skipping run as none of the required directories exist.")
+            logging.info(
+                f"{os.path.basename(run_path)}: Skipping run as none of the required directories exist."
+            )
             continue
         dump_path(run_path)
         dump_pore_count_history(run_path=run_path, pore_counts=pore_counts)

--- a/taca/utils/config.py
+++ b/taca/utils/config.py
@@ -2,7 +2,7 @@
 
 import yaml
 
-CONFIG = {}
+CONFIG: dict = {}
 
 
 def load_config(config_file):

--- a/tests/nanopore/test_instrument_transfer.py
+++ b/tests/nanopore/test_instrument_transfer.py
@@ -113,6 +113,7 @@ def test_main_ongoing_run(mock_popen, mock_check_output, mock_run, setup_test_fi
     # Set up ONT run
     run_path = f"{args.local_runs}/experiment/sample/{DUMMY_RUN_NAME}"
     os.makedirs(run_path)
+    os.makedirs(f"{run_path}/fastq_pass")
 
     # Start testing
     instrument_transfer.main(args)


### PR DESCRIPTION
To prevent syncing runs that failed to start sequencing, skip run if none of the following directories exist: "fastq_fail", "fastq_pass", "bam_fail", "bam_pass".